### PR TITLE
Interpret "no timeout" as infinite.

### DIFF
--- a/pkg/reconciler/contour/resources/httpproxy.go
+++ b/pkg/reconciler/contour/resources/httpproxy.go
@@ -78,6 +78,10 @@ func MakeHTTPProxies(ctx context.Context, ing *v1alpha1.Ingress, serviceToProtoc
 				top = &v1.TimeoutPolicy{
 					Response: path.Timeout.Duration.String(),
 				}
+			} else {
+				top = &v1.TimeoutPolicy{
+					Response: "infinity",
+				}
 			}
 
 			var retry *v1.RetryPolicy

--- a/pkg/reconciler/contour/resources/httpproxy_test.go
+++ b/pkg/reconciler/contour/resources/httpproxy_test.go
@@ -118,6 +118,9 @@ func TestMakeProxies(t *testing.T) {
 				Routes: []v1.Route{{
 					EnableWebsockets: true,
 					PermitInsecure:   true,
+					TimeoutPolicy: &v1.TimeoutPolicy{
+						Response: "infinity",
+					},
 					RequestHeadersPolicy: &v1.HeadersPolicy{
 						Set: []v1.HeaderValue{{
 							Name:  "Foo",
@@ -209,6 +212,9 @@ func TestMakeProxies(t *testing.T) {
 				Routes: []v1.Route{{
 					EnableWebsockets: true,
 					PermitInsecure:   true,
+					TimeoutPolicy: &v1.TimeoutPolicy{
+						Response: "infinity",
+					},
 					RequestHeadersPolicy: &v1.HeadersPolicy{
 						Set: []v1.HeaderValue{{
 							Name:  "K-Network-Hash",
@@ -250,6 +256,9 @@ func TestMakeProxies(t *testing.T) {
 				Routes: []v1.Route{{
 					EnableWebsockets: true,
 					PermitInsecure:   true,
+					TimeoutPolicy: &v1.TimeoutPolicy{
+						Response: "infinity",
+					},
 					RequestHeadersPolicy: &v1.HeadersPolicy{
 						Set: []v1.HeaderValue{{
 							Name:  "K-Network-Hash",
@@ -291,6 +300,9 @@ func TestMakeProxies(t *testing.T) {
 				Routes: []v1.Route{{
 					EnableWebsockets: true,
 					PermitInsecure:   true,
+					TimeoutPolicy: &v1.TimeoutPolicy{
+						Response: "infinity",
+					},
 					RequestHeadersPolicy: &v1.HeadersPolicy{
 						Set: []v1.HeaderValue{{
 							Name:  "K-Network-Hash",
@@ -465,6 +477,9 @@ func TestMakeProxies(t *testing.T) {
 					}},
 					EnableWebsockets: true,
 					PermitInsecure:   true,
+					TimeoutPolicy: &v1.TimeoutPolicy{
+						Response: "infinity",
+					},
 					RequestHeadersPolicy: &v1.HeadersPolicy{
 						Set: []v1.HeaderValue{{
 							Name:  "K-Network-Hash",
@@ -488,6 +503,9 @@ func TestMakeProxies(t *testing.T) {
 					}},
 					EnableWebsockets: true,
 					PermitInsecure:   true,
+					TimeoutPolicy: &v1.TimeoutPolicy{
+						Response: "infinity",
+					},
 					RequestHeadersPolicy: &v1.HeadersPolicy{
 						Set: []v1.HeaderValue{{
 							Name:  "K-Network-Hash",
@@ -578,6 +596,9 @@ func TestMakeProxies(t *testing.T) {
 				Routes: []v1.Route{{
 					EnableWebsockets: true,
 					PermitInsecure:   false,
+					TimeoutPolicy: &v1.TimeoutPolicy{
+						Response: "infinity",
+					},
 					RequestHeadersPolicy: &v1.HeadersPolicy{
 						Set: []v1.HeaderValue{{
 							Name:  "Foo",
@@ -688,6 +709,9 @@ func TestMakeProxies(t *testing.T) {
 				Routes: []v1.Route{{
 					EnableWebsockets: true,
 					PermitInsecure:   true,
+					TimeoutPolicy: &v1.TimeoutPolicy{
+						Response: "infinity",
+					},
 					RequestHeadersPolicy: &v1.HeadersPolicy{
 						Set: []v1.HeaderValue{{
 							Name:  "Foo",


### PR DESCRIPTION
The defaulting of our kingress timeouts was recently dropped: https://github.com/knative/networking/pull/22, though I have a PR to roll this back until it can follow proper process and get conformance coverage.

Currently net-contour implements this via Contour default, which uses Envoy defaults, which is 15s.

I believe the intended behavior of this is to be "no timeout", which is what this implements.