### PR TITLE
Filter on the OwnerRef GroupKind.

### DIFF
--- a/pkg/reconciler/contour/controller.go
+++ b/pkg/reconciler/contour/controller.go
@@ -86,7 +86,10 @@ func NewController(
 	}
 	ingressInformer.Informer().AddEventHandler(ingressHandler)
 
-	proxyInformer.Informer().AddEventHandler(controller.HandleAll(impl.EnqueueControllerOf))
+	proxyInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
+		FilterFunc: controller.FilterControllerGK(v1alpha1.Kind("Ingress")),
+		Handler:    controller.HandleAll(impl.EnqueueControllerOf),
+	})
 
 	statusProber := status.NewProber(
 		logger.Named("status-manager"),


### PR DESCRIPTION
Previously this blindly enqueued the Owner's key, but it should filter out instances owned by KIngress resources to avoid trigger excess reconciles (likely of non-existing keys).

I noticed this experimenting with some changes that should improve our reliability a whole bunch.