### PR TITLE
Add a scheme for warming Endpoints before rolling our kingress changes.

### DIFF
--- a/pkg/reconciler/contour/resources/constants.go
+++ b/pkg/reconciler/contour/resources/constants.go
@@ -29,4 +29,8 @@ const (
 	// the hash in place of the actual fqdn because there is a limit on the length of label
 	// values.
 	DomainHashKey = "contour.networking.knative.dev/domainHash"
+
+	// EndpointsProbeKey is placed on child Ingress resources to bypass Endpoint probing,
+	// since the child ingress exists to be said endpoint probe.
+	EndpointsProbeKey = "contour.networking.knative.dev/endpointsProbe"
 )

--- a/pkg/reconciler/contour/resources/httpproxy_test.go
+++ b/pkg/reconciler/contour/resources/httpproxy_test.go
@@ -829,7 +829,11 @@ func TestServiceNames(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			got := ServiceNames(context.Background(), test.ing)
+			sns := ServiceNames(context.Background(), test.ing)
+			got := make(sets.String, len(sns))
+			for key := range sns {
+				got.Insert(key)
+			}
 			if !cmp.Equal(test.want, got) {
 				t.Errorf("ServiceNames (-want, +got): %s", cmp.Diff(test.want, got))
 			}

--- a/pkg/reconciler/contour/resources/kingress.go
+++ b/pkg/reconciler/contour/resources/kingress.go
@@ -1,0 +1,70 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resources
+
+import (
+	"context"
+	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"knative.dev/networking/pkg/apis/networking/v1alpha1"
+	"knative.dev/pkg/kmeta"
+)
+
+func MakeEndpointProbeIngress(ctx context.Context, ing *v1alpha1.Ingress) *v1alpha1.Ingress {
+	childIng := &v1alpha1.Ingress{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      kmeta.ChildName(ing.Name+"--", "ep"),
+			Namespace: ing.Namespace,
+			Labels:    ing.Labels,
+			Annotations: kmeta.UnionMaps(ing.Annotations, map[string]string{
+				EndpointsProbeKey: "true",
+			}),
+			OwnerReferences: []metav1.OwnerReference{*kmeta.NewControllerRef(ing)},
+		},
+	}
+
+	sns := ServiceNames(ctx, ing)
+	order := make(sets.String, len(sns))
+	for key := range sns {
+		order.Insert(key)
+	}
+
+	for _, name := range order.List() {
+		si := sns[name]
+		for _, vis := range si.Visibilities {
+			childIng.Spec.Rules = append(childIng.Spec.Rules, v1alpha1.IngressRule{
+				Hosts:      []string{fmt.Sprintf("%s.%s.%s.net-contour.invalid", name, ing.Name, ing.Namespace)},
+				Visibility: vis,
+				HTTP: &v1alpha1.HTTPIngressRuleValue{
+					Paths: []v1alpha1.HTTPIngressPath{{
+						Splits: []v1alpha1.IngressBackendSplit{{
+							IngressBackend: v1alpha1.IngressBackend{
+								ServiceName:      name,
+								ServiceNamespace: ing.Namespace,
+								ServicePort:      si.Port,
+							},
+						}},
+					}},
+				},
+			})
+		}
+	}
+
+	return childIng
+}

--- a/pkg/reconciler/contour/resources/kingress_test.go
+++ b/pkg/reconciler/contour/resources/kingress_test.go
@@ -1,0 +1,350 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resources
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"knative.dev/networking/pkg/apis/networking/v1alpha1"
+	"knative.dev/pkg/network"
+	"knative.dev/pkg/ptr"
+)
+
+func TestMakeEndpointProbeIngress(t *testing.T) {
+	tests := []struct {
+		name string
+		ing  *v1alpha1.Ingress
+		want *v1alpha1.Ingress
+	}{{
+		name: "single external domain with split",
+		ing: &v1alpha1.Ingress{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "foo",
+				Name:      "bar",
+			},
+			Spec: v1alpha1.IngressSpec{
+				Rules: []v1alpha1.IngressRule{{
+					Hosts:      []string{"example.com"},
+					Visibility: v1alpha1.IngressVisibilityExternalIP,
+					HTTP: &v1alpha1.HTTPIngressRuleValue{
+						Paths: []v1alpha1.HTTPIngressPath{{
+							AppendHeaders: map[string]string{
+								"Foo": "bar",
+							},
+							Splits: []v1alpha1.IngressBackendSplit{{
+								IngressBackend: v1alpha1.IngressBackend{
+									ServiceName: "goo",
+									ServicePort: intstr.FromInt(123),
+								},
+								Percent: 12,
+								AppendHeaders: map[string]string{
+									"Baz":   "blah",
+									"Bleep": "bloop",
+								},
+							}, {
+								IngressBackend: v1alpha1.IngressBackend{
+									ServiceName: "doo",
+									ServicePort: intstr.FromInt(124),
+								},
+								Percent: 88,
+								AppendHeaders: map[string]string{
+									"Baz": "blurg",
+								},
+							}},
+						}},
+					},
+				}},
+			},
+		},
+		want: &v1alpha1.Ingress{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "foo",
+				Name:      "bar--ep",
+				Annotations: map[string]string{
+					EndpointsProbeKey: "true",
+				},
+				OwnerReferences: []metav1.OwnerReference{{
+					APIVersion:         "networking.internal.knative.dev/v1alpha1",
+					Kind:               "Ingress",
+					Name:               "bar",
+					Controller:         ptr.Bool(true),
+					BlockOwnerDeletion: ptr.Bool(true),
+				}},
+			},
+			Spec: v1alpha1.IngressSpec{
+				Rules: []v1alpha1.IngressRule{{
+					Hosts:      []string{"doo.bar.foo.net-contour.invalid"},
+					Visibility: v1alpha1.IngressVisibilityExternalIP,
+					HTTP: &v1alpha1.HTTPIngressRuleValue{
+						Paths: []v1alpha1.HTTPIngressPath{{
+							Splits: []v1alpha1.IngressBackendSplit{{
+								IngressBackend: v1alpha1.IngressBackend{
+									ServiceNamespace: "foo",
+									ServiceName:      "doo",
+									ServicePort:      intstr.FromInt(124),
+								},
+							}},
+						}},
+					},
+				}, {
+					Hosts:      []string{"goo.bar.foo.net-contour.invalid"},
+					Visibility: v1alpha1.IngressVisibilityExternalIP,
+					HTTP: &v1alpha1.HTTPIngressRuleValue{
+						Paths: []v1alpha1.HTTPIngressPath{{
+							Splits: []v1alpha1.IngressBackendSplit{{
+								IngressBackend: v1alpha1.IngressBackend{
+									ServiceNamespace: "foo",
+									ServiceName:      "goo",
+									ServicePort:      intstr.FromInt(123),
+								},
+							}},
+						}},
+					},
+				}},
+			},
+		},
+	}, {
+		// I'm not thrilled that the domain is special cased here,
+		// but those are the current semantics.
+		name: "external visibility with internal domain",
+		ing: &v1alpha1.Ingress{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "foo",
+				Name:      "bar",
+			},
+			Spec: v1alpha1.IngressSpec{
+				Rules: []v1alpha1.IngressRule{{
+					Hosts:      []string{network.GetServiceHostname("foo", "bar")},
+					Visibility: v1alpha1.IngressVisibilityExternalIP,
+					HTTP: &v1alpha1.HTTPIngressRuleValue{
+						Paths: []v1alpha1.HTTPIngressPath{{
+							Splits: []v1alpha1.IngressBackendSplit{{
+								IngressBackend: v1alpha1.IngressBackend{
+									ServiceName: "goo",
+									ServicePort: intstr.FromInt(123),
+								},
+								Percent: 100,
+							}},
+						}},
+					},
+				}},
+			},
+		},
+		want: &v1alpha1.Ingress{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "foo",
+				Name:      "bar--ep",
+				Annotations: map[string]string{
+					EndpointsProbeKey: "true",
+				},
+				OwnerReferences: []metav1.OwnerReference{{
+					APIVersion:         "networking.internal.knative.dev/v1alpha1",
+					Kind:               "Ingress",
+					Name:               "bar",
+					Controller:         ptr.Bool(true),
+					BlockOwnerDeletion: ptr.Bool(true),
+				}},
+			},
+			Spec: v1alpha1.IngressSpec{
+				Rules: []v1alpha1.IngressRule{{
+					Hosts:      []string{"goo.bar.foo.net-contour.invalid"},
+					Visibility: v1alpha1.IngressVisibilityExternalIP,
+					HTTP: &v1alpha1.HTTPIngressRuleValue{
+						Paths: []v1alpha1.HTTPIngressPath{{
+							Splits: []v1alpha1.IngressBackendSplit{{
+								IngressBackend: v1alpha1.IngressBackend{
+									ServiceNamespace: "foo",
+									ServiceName:      "goo",
+									ServicePort:      intstr.FromInt(123),
+								},
+							}},
+						}},
+					},
+				}},
+			},
+		},
+	}, {
+		name: "cluster local visibility with retry policy and timeout",
+		ing: &v1alpha1.Ingress{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "foo",
+				Name:      "bar",
+			},
+			Spec: v1alpha1.IngressSpec{
+				Rules: []v1alpha1.IngressRule{{
+					Hosts:      []string{"example.com"},
+					Visibility: v1alpha1.IngressVisibilityClusterLocal,
+					HTTP: &v1alpha1.HTTPIngressRuleValue{
+						Paths: []v1alpha1.HTTPIngressPath{{
+							Retries: &v1alpha1.HTTPRetry{
+								Attempts:      34,
+								PerTryTimeout: &metav1.Duration{14 * time.Minute},
+							},
+							Timeout: &metav1.Duration{46 * time.Minute},
+							Splits: []v1alpha1.IngressBackendSplit{{
+								IngressBackend: v1alpha1.IngressBackend{
+									ServiceName: "goo",
+									ServicePort: intstr.FromInt(123),
+								},
+								Percent: 100,
+							}},
+						}},
+					},
+				}},
+			},
+		},
+		want: &v1alpha1.Ingress{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "foo",
+				Name:      "bar--ep",
+				Annotations: map[string]string{
+					EndpointsProbeKey: "true",
+				},
+				OwnerReferences: []metav1.OwnerReference{{
+					APIVersion:         "networking.internal.knative.dev/v1alpha1",
+					Kind:               "Ingress",
+					Name:               "bar",
+					Controller:         ptr.Bool(true),
+					BlockOwnerDeletion: ptr.Bool(true),
+				}},
+			},
+			Spec: v1alpha1.IngressSpec{
+				Rules: []v1alpha1.IngressRule{{
+					Hosts:      []string{"goo.bar.foo.net-contour.invalid"},
+					Visibility: v1alpha1.IngressVisibilityClusterLocal,
+					HTTP: &v1alpha1.HTTPIngressRuleValue{
+						Paths: []v1alpha1.HTTPIngressPath{{
+							Splits: []v1alpha1.IngressBackendSplit{{
+								IngressBackend: v1alpha1.IngressBackend{
+									ServiceNamespace: "foo",
+									ServiceName:      "goo",
+									ServicePort:      intstr.FromInt(123),
+								},
+							}},
+						}},
+					},
+				}},
+			},
+		},
+	}, {
+		name: "multiple paths with header conditions",
+		ing: &v1alpha1.Ingress{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "foo",
+				Name:      "bar",
+			},
+			Spec: v1alpha1.IngressSpec{
+				Rules: []v1alpha1.IngressRule{{
+					Hosts:      []string{"example.com"},
+					Visibility: v1alpha1.IngressVisibilityExternalIP,
+					HTTP: &v1alpha1.HTTPIngressRuleValue{
+						Paths: []v1alpha1.HTTPIngressPath{{
+							Path: "/goo",
+							Headers: map[string]v1alpha1.HeaderMatch{
+								"tag": {
+									Exact: "goo",
+								},
+							},
+							Splits: []v1alpha1.IngressBackendSplit{{
+								IngressBackend: v1alpha1.IngressBackend{
+									ServiceName: "goo",
+									ServicePort: intstr.FromInt(123),
+								},
+								Percent: 100,
+							}},
+						}, {
+							Path: "/doo",
+							Headers: map[string]v1alpha1.HeaderMatch{
+								"tag": {
+									Exact: "doo",
+								},
+							},
+							Splits: []v1alpha1.IngressBackendSplit{{
+								IngressBackend: v1alpha1.IngressBackend{
+									ServiceName: "doo",
+									ServicePort: intstr.FromInt(124),
+								},
+								Percent: 100,
+							}},
+						}},
+					},
+				}},
+			},
+		},
+		want: &v1alpha1.Ingress{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "foo",
+				Name:      "bar--ep",
+				Annotations: map[string]string{
+					EndpointsProbeKey: "true",
+				},
+				OwnerReferences: []metav1.OwnerReference{{
+					APIVersion:         "networking.internal.knative.dev/v1alpha1",
+					Kind:               "Ingress",
+					Name:               "bar",
+					Controller:         ptr.Bool(true),
+					BlockOwnerDeletion: ptr.Bool(true),
+				}},
+			},
+			Spec: v1alpha1.IngressSpec{
+				Rules: []v1alpha1.IngressRule{{
+					Hosts:      []string{"doo.bar.foo.net-contour.invalid"},
+					Visibility: v1alpha1.IngressVisibilityExternalIP,
+					HTTP: &v1alpha1.HTTPIngressRuleValue{
+						Paths: []v1alpha1.HTTPIngressPath{{
+							Splits: []v1alpha1.IngressBackendSplit{{
+								IngressBackend: v1alpha1.IngressBackend{
+									ServiceNamespace: "foo",
+									ServiceName:      "doo",
+									ServicePort:      intstr.FromInt(124),
+								},
+							}},
+						}},
+					},
+				}, {
+					Hosts:      []string{"goo.bar.foo.net-contour.invalid"},
+					Visibility: v1alpha1.IngressVisibilityExternalIP,
+					HTTP: &v1alpha1.HTTPIngressRuleValue{
+						Paths: []v1alpha1.HTTPIngressPath{{
+							Splits: []v1alpha1.IngressBackendSplit{{
+								IngressBackend: v1alpha1.IngressBackend{
+									ServiceNamespace: "foo",
+									ServiceName:      "goo",
+									ServicePort:      intstr.FromInt(123),
+								},
+							}},
+						}},
+					},
+				}},
+			},
+		},
+	}}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := MakeEndpointProbeIngress(context.Background(), test.ing)
+			if !cmp.Equal(test.want, got) {
+				t.Errorf("MakeHTTPProxies (-want, +got) = %s", cmp.Diff(test.want, got))
+			}
+		})
+	}
+}

--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -60,7 +60,7 @@ function scale_controlplane() {
     # Give it time to kill the pods.
     sleep 5
     # Scale up components for HA tests
-    kubectl -n knative-serving scale deployment "$deployment" --replicas=2 || failed=1
+    kubectl -n knative-serving scale deployment "$deployment" --replicas=3 || failed=1
   done
 }
 

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -20,11 +20,8 @@ source $(dirname $0)/e2e-common.sh
 # Script entry point.
 initialize $@  --skip-istio-addon
 
-# TODO(#12): TestUpdate is consistently failing. So we skip it
-
 go_test_e2e -timeout=20m -parallel=12 \
 	    ./test/conformance \
-	     -run="/^[^u]" \
 	    --ingressClass=contour.ingress.networking.knative.dev || fail_test
 
 success


### PR DESCRIPTION
This is based on the sketch here: https://docs.google.com/document/d/11k0d0STquDFYBp_43I2AQQVDqQ22ZWfnon7RmJBcc2s/edit#

Contour has a race when it rolls out programming to Envoys where the routing
data can land prior to the endpoint data.  This is due to the fact that Contour
filters our Endpoints that aren't referenced by the routing layer to reduce the
amount of information it distributes, however, this means that when migrating
traffic to a new service that the Envoys have not seen before, the Envoys may
be directed to send traffic to Endpoints for which it has not yet received data.

This problem is especially bad for Knative because every Revision rolls out a
service that the Envoys haven't seen before, so virtually every rollout risks
a blip of 503s, which we actually see manifest fairly regularly in the e2e
testing, and which the TestUpdate kingress conformance test has exacerbated
for a while.

The solution in this pull request builds on the prior work to probe the Envoys
to ensure programming has been distributed.  It breaks the kingress
reconciliation down into two discrete phases:
1. Distribute artificial programming that references all of the Endpoints of
  our new programming.  Once probing has confirmed that to be Ready, then we...
2. Distribute the actual programming that references the new Endpoints, which
  we have confirmed the Envoys are aware of.

The implementation of this two-phased approach is done via a shallow recursion.
We create a secondary kingress targetting the appropriate Envoy pools with bogus
hostnames, and an annotation to block further recursion.  Once this "endpoint
probe" kingress has reported Ready, then we proceed with the remained of the
Contour reconciliation as we had it before, but now with the guarantee that the
Endpoints data is present.

Fixes: https://github.com/knative-sandbox/net-contour/issues/12

This should fix the longstanding TestUpdate issue, which I ran successfully (in
isolation) a half dozen times last night.

Related to: https://github.com/projectcontour/contour/issues/2151

I've tried to limit the scope of this change, but there are a handful of follow
ups I intend to make once this starts baking:

1. https://github.com/knative-sandbox/net-contour/issues/165: I noticed this
  making this change and it means that we are violating the "no calls on nops"
  rule for reconcilers.

2. Clean up the endpoints probe kingress resources.  I added a bool for this and
  a TODO, but I want to circle back to that once this has landed.  Technically
  what this PR does is sufficient for correctness, but it will scale better if
  we don't leave around the garbage programming.

3. Clean up the legacy Endpoints checking, which is subsumed by this and is now
  unnecessary complexity.