### PR TITLE
Improve the net-contour logging story.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/google/go-cmp v0.5.1
 	github.com/mikefarah/yq/v3 v3.0.0-20200601230220-721dd57ed41b
 	github.com/projectcontour/contour v1.4.1-0.20200507033955-65d52b253570
+	go.uber.org/zap v1.15.0
 	gopkg.in/yaml.v2 v2.3.0
 	k8s.io/api v0.18.7-rc.0
 	k8s.io/apimachinery v0.18.7-rc.0

--- a/pkg/reconciler/contour/contour.go
+++ b/pkg/reconciler/contour/contour.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 
+	"go.uber.org/zap"
 	"k8s.io/apimachinery/pkg/api/equality"
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -131,7 +132,7 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, ing *v1alpha1.Ingress) r
 			if diff, err := kmp.SafeDiff(desiredChIng.Spec, actualChIng.Spec); err == nil {
 				logger.Debugf("Updated endpoint probe: %s", diff)
 			} else {
-				logger.Warnf("Error diffing endpoint probes: %v", err)
+				logger.Warnw("Error diffing endpoint probes", zap.Error(err))
 			}
 		}
 
@@ -214,7 +215,7 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, ing *v1alpha1.Ingress) r
 		if diff, err := kmp.SafeDiff(update, elts[0]); err == nil {
 			logger.Debugf("Updated http proxy: %s", diff)
 		} else {
-			logger.Warnf("Error diffing http proxy: %v", err)
+			logger.Warnw("Error diffing http proxy", zap.Error(err))
 		}
 	}
 

--- a/pkg/reconciler/contour/contour.go
+++ b/pkg/reconciler/contour/contour.go
@@ -40,6 +40,8 @@ import (
 	"knative.dev/networking/pkg/apis/networking"
 	"knative.dev/networking/pkg/apis/networking/v1alpha1"
 	"knative.dev/networking/pkg/status"
+	"knative.dev/pkg/kmp"
+	"knative.dev/pkg/logging"
 	"knative.dev/pkg/network"
 	"knative.dev/pkg/reconciler"
 	"knative.dev/pkg/tracker"
@@ -69,6 +71,7 @@ var _ ingressreconciler.Interface = (*Reconciler)(nil)
 
 // ReconcileKind reconciles ingress resource.
 func (r *Reconciler) ReconcileKind(ctx context.Context, ing *v1alpha1.Ingress) reconciler.Event {
+	logger := logging.FromContext(ctx)
 
 	// Track whether there is an endpoint probe kingress to clean up.
 	haveEndpointProbe := false
@@ -77,6 +80,7 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, ing *v1alpha1.Ingress) r
 		// We only create an Endpoint probe kingress for top-level net-contour
 		// kingress. Stop recursing when we see our annotation and proceed to
 		// HTTP Proxy and probing.
+		logger.Debug("Avoiding endpoint probe recursion.")
 	} else
 	// See if we have any HTTPProxy resources for this generation.
 	// We only create HTTPProxy resources once we have successfully probed
@@ -105,6 +109,7 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, ing *v1alpha1.Ingress) r
 		if err != nil {
 			return err
 		}
+		logger.Debugf("Found %d HTTP Proxies from older generations.", len(elts))
 
 		desiredChIng := resources.MakeEndpointProbeIngress(ctx, ing, elts)
 		actualChIng, err := r.ingressLister.Ingresses(desiredChIng.Namespace).Get(desiredChIng.Name)
@@ -113,6 +118,7 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, ing *v1alpha1.Ingress) r
 			if err != nil {
 				return err
 			}
+			logger.Debugf("Created endpoint probe: %v", actualChIng)
 		} else if err != nil {
 			return err
 		} else if !equality.Semantic.DeepEqual(actualChIng.Spec, desiredChIng.Spec) { // Reconcile it.
@@ -121,6 +127,11 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, ing *v1alpha1.Ingress) r
 			actualChIng, err = r.ingressClient.NetworkingV1alpha1().Ingresses(actualChIng.Namespace).Update(actualChIng)
 			if err != nil {
 				return err
+			}
+			if diff, err := kmp.SafeDiff(desiredChIng.Spec, actualChIng.Spec); err == nil {
+				logger.Debugf("Updated endpoint probe: %s", diff)
+			} else {
+				logger.Warnf("Error diffing endpoint probes: %v", err)
 			}
 		}
 
@@ -131,9 +142,15 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, ing *v1alpha1.Ingress) r
 
 		// The endpoints ingress is ready, we are good to go!
 		haveEndpointProbe = true
+		logger.Debugf("We have an endpoint probe: %#v.", actualChIng)
 	} else {
-		_, err := r.ingressLister.Ingresses(ing.Namespace).Get(names.EndpointProbeIngress(ing))
+		ing, err := r.ingressLister.Ingresses(ing.Namespace).Get(names.EndpointProbeIngress(ing))
 		haveEndpointProbe = !apierrs.IsNotFound(err)
+		if haveEndpointProbe {
+			logger.Debugf("We have an endpoint probe: %#v.", ing)
+		} else {
+			logger.Debug("We do not have an endpoint probe.")
+		}
 	}
 
 	info := resources.ServiceNames(ctx, ing)
@@ -176,9 +193,11 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, ing *v1alpha1.Ingress) r
 			return err
 		}
 		if len(elts) == 0 {
-			if _, err := r.contourClient.ProjectcontourV1().HTTPProxies(proxy.Namespace).Create(proxy); err != nil {
+			proxy, err := r.contourClient.ProjectcontourV1().HTTPProxies(proxy.Namespace).Create(proxy)
+			if err != nil {
 				return err
 			}
+			logger.Debugf("Created http proxy: %#v", proxy)
 			continue
 		}
 		update := elts[0].DeepCopy()
@@ -191,6 +210,11 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, ing *v1alpha1.Ingress) r
 		}
 		if _, err = r.contourClient.ProjectcontourV1().HTTPProxies(proxy.Namespace).Update(update); err != nil {
 			return err
+		}
+		if diff, err := kmp.SafeDiff(update, elts[0]); err == nil {
+			logger.Debugf("Updated http proxy: %s", diff)
+		} else {
+			logger.Warnf("Error diffing http proxy: %v", err)
 		}
 	}
 
@@ -206,6 +230,7 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, ing *v1alpha1.Ingress) r
 			&metav1.DeleteOptions{}, metav1.ListOptions{LabelSelector: selector.String()}); err != nil {
 			return err
 		}
+		logger.Debugf("Deleted %d older http proxies.", len(elts))
 	}
 	ing.Status.MarkNetworkConfigured()
 
@@ -213,6 +238,7 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, ing *v1alpha1.Ingress) r
 	if err != nil {
 		return fmt.Errorf("failed to probe Ingress %s/%s: %w", ing.GetNamespace(), ing.GetName(), err)
 	}
+	logger.Debugf("Status prober returned %v.", ready)
 	if ready {
 		ing.Status.MarkLoadBalancerReady(
 			[]v1alpha1.LoadBalancerIngressStatus{},
@@ -225,6 +251,7 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, ing *v1alpha1.Ingress) r
 				names.EndpointProbeIngress(ing), &metav1.DeleteOptions{}); err != nil {
 				return err
 			}
+			logger.Debug("Deleted endpoint probe.")
 		}
 	} else {
 		ing.Status.MarkLoadBalancerNotReady()

--- a/pkg/reconciler/contour/resources/kingress.go
+++ b/pkg/reconciler/contour/resources/kingress.go
@@ -28,6 +28,7 @@ import (
 	"knative.dev/net-contour/pkg/reconciler/contour/resources/names"
 	"knative.dev/networking/pkg/apis/networking/v1alpha1"
 	"knative.dev/pkg/kmeta"
+	"knative.dev/pkg/logging"
 )
 
 func MakeEndpointProbeIngress(ctx context.Context, ing *v1alpha1.Ingress, previousState []*v1.HTTPProxy) *v1alpha1.Ingress {
@@ -88,7 +89,10 @@ func MakeEndpointProbeIngress(ctx context.Context, ing *v1alpha1.Ingress, previo
 		order.Insert(key)
 	}
 
-	for _, name := range order.List() {
+	l := order.List()
+	logging.FromContext(ctx).Debugf("Endpoints probe will cover services: %v", l)
+
+	for _, name := range l {
 		si := sns[name]
 		for _, vis := range si.Visibilities {
 			childIng.Spec.Rules = append(childIng.Spec.Rules, v1alpha1.IngressRule{

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -282,6 +282,7 @@ go.uber.org/atomic
 # go.uber.org/multierr v1.5.0
 go.uber.org/multierr
 # go.uber.org/zap v1.15.0
+## explicit
 go.uber.org/zap
 go.uber.org/zap/buffer
 go.uber.org/zap/internal/bufferpool


### PR DESCRIPTION
This is fairly aggressive about logging at Debug level to improve debugging with logstream in our e2e tests (which enable debug-level logging).

This highlighted some fun problems pretty quickly for me, so I wanted to land them upstream.