### PR TITLE
Fix a bad assumption in the HTTP Proxy logic.

### DIFF
--- a/pkg/reconciler/contour/contour.go
+++ b/pkg/reconciler/contour/contour.go
@@ -188,6 +188,7 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, ing *v1alpha1.Ingress) r
 		selector := labels.Set(map[string]string{
 			resources.ParentKey:     proxy.Labels[resources.ParentKey],
 			resources.DomainHashKey: proxy.Labels[resources.DomainHashKey],
+			resources.ClassKey:      proxy.Labels[resources.ClassKey],
 		}).AsSelector()
 		elts, err := r.contourLister.HTTPProxies(ing.Namespace).List(selector)
 		if err != nil {

--- a/pkg/reconciler/contour/resources/constants.go
+++ b/pkg/reconciler/contour/resources/constants.go
@@ -30,6 +30,10 @@ const (
 	// values.
 	DomainHashKey = "contour.networking.knative.dev/domainHash"
 
+	// ClassKey contains the name of the contour class annotation used to select the
+	// Contour instance that handles a given HTTP Proxy.
+	ClassKey = "projectcontour.io/ingress.class"
+
 	// EndpointsProbeKey is placed on child Ingress resources to bypass Endpoint probing,
 	// since the child ingress exists to be said endpoint probe.
 	EndpointsProbeKey = "contour.networking.knative.dev/endpointsProbe"

--- a/pkg/reconciler/contour/resources/httpproxy_test.go
+++ b/pkg/reconciler/contour/resources/httpproxy_test.go
@@ -94,14 +94,15 @@ func TestMakeProxies(t *testing.T) {
 		want: []*v1.HTTPProxy{{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: "foo",
-				Name:      "bar-example.com",
+				Name:      "bar-" + publicClass + "-example.com",
 				Labels: map[string]string{
 					DomainHashKey: "0caaf24ab1a0c33440c06afe99df986365b0781f",
 					GenerationKey: "0",
 					ParentKey:     "bar",
+					ClassKey:      publicClass,
 				},
 				Annotations: map[string]string{
-					"projectcontour.io/ingress.class": publicClass,
+					ClassKey: publicClass,
 				},
 				OwnerReferences: []metav1.OwnerReference{{
 					APIVersion:         "networking.internal.knative.dev/v1alpha1",
@@ -188,14 +189,15 @@ func TestMakeProxies(t *testing.T) {
 		want: []*v1.HTTPProxy{{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: "foo",
-				Name:      "bar-foo.bar",
+				Name:      "bar-" + privateClass + "-foo.bar",
 				Labels: map[string]string{
 					DomainHashKey: "336d1b3d72e061b98b59d6c793f6a8da217a727a",
 					GenerationKey: "0",
 					ParentKey:     "bar",
+					ClassKey:      privateClass,
 				},
 				Annotations: map[string]string{
-					"projectcontour.io/ingress.class": privateClass,
+					ClassKey: privateClass,
 				},
 				OwnerReferences: []metav1.OwnerReference{{
 					APIVersion:         "networking.internal.knative.dev/v1alpha1",
@@ -232,14 +234,15 @@ func TestMakeProxies(t *testing.T) {
 		}, {
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: "foo",
-				Name:      "bar-foo.bar.svc",
+				Name:      "bar-" + privateClass + "-foo.bar.svc",
 				Labels: map[string]string{
 					DomainHashKey: "c537bbef14c1570803e5c51c6ca824524c758496",
 					GenerationKey: "0",
 					ParentKey:     "bar",
+					ClassKey:      privateClass,
 				},
 				Annotations: map[string]string{
-					"projectcontour.io/ingress.class": privateClass,
+					ClassKey: privateClass,
 				},
 				OwnerReferences: []metav1.OwnerReference{{
 					APIVersion:         "networking.internal.knative.dev/v1alpha1",
@@ -276,14 +279,15 @@ func TestMakeProxies(t *testing.T) {
 		}, {
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: "foo",
-				Name:      "bar-foo.bar.svc.cluster.local",
+				Name:      "bar-" + privateClass + "-foo.bar.svc.cluster.local",
 				Labels: map[string]string{
 					DomainHashKey: "6f498a962729705e1c12fdef2c3371c00f5094e9",
 					GenerationKey: "0",
 					ParentKey:     "bar",
+					ClassKey:      privateClass,
 				},
 				Annotations: map[string]string{
-					"projectcontour.io/ingress.class": privateClass,
+					ClassKey: privateClass,
 				},
 				OwnerReferences: []metav1.OwnerReference{{
 					APIVersion:         "networking.internal.knative.dev/v1alpha1",
@@ -351,14 +355,15 @@ func TestMakeProxies(t *testing.T) {
 		want: []*v1.HTTPProxy{{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: "foo",
-				Name:      "bar-example.com",
+				Name:      "bar-" + privateClass + "-example.com",
 				Labels: map[string]string{
 					DomainHashKey: "0caaf24ab1a0c33440c06afe99df986365b0781f",
 					GenerationKey: "0",
 					ParentKey:     "bar",
+					ClassKey:      privateClass,
 				},
 				Annotations: map[string]string{
-					"projectcontour.io/ingress.class": privateClass,
+					ClassKey: privateClass,
 				},
 				OwnerReferences: []metav1.OwnerReference{{
 					APIVersion:         "networking.internal.knative.dev/v1alpha1",
@@ -445,14 +450,15 @@ func TestMakeProxies(t *testing.T) {
 		want: []*v1.HTTPProxy{{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: "foo",
-				Name:      "bar-example.com",
+				Name:      "bar-" + publicClass + "-example.com",
 				Labels: map[string]string{
 					DomainHashKey: "0caaf24ab1a0c33440c06afe99df986365b0781f",
 					GenerationKey: "0",
 					ParentKey:     "bar",
+					ClassKey:      publicClass,
 				},
 				Annotations: map[string]string{
-					"projectcontour.io/ingress.class": publicClass,
+					ClassKey: publicClass,
 				},
 				OwnerReferences: []metav1.OwnerReference{{
 					APIVersion:         "networking.internal.knative.dev/v1alpha1",
@@ -569,14 +575,15 @@ func TestMakeProxies(t *testing.T) {
 		want: []*v1.HTTPProxy{{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: "foo",
-				Name:      "bar-example.com",
+				Name:      "bar-" + publicClass + "-example.com",
 				Labels: map[string]string{
 					DomainHashKey: "0caaf24ab1a0c33440c06afe99df986365b0781f",
 					GenerationKey: "0",
 					ParentKey:     "bar",
+					ClassKey:      publicClass,
 				},
 				Annotations: map[string]string{
-					"projectcontour.io/ingress.class": publicClass,
+					ClassKey: publicClass,
 				},
 				OwnerReferences: []metav1.OwnerReference{{
 					APIVersion:         "networking.internal.knative.dev/v1alpha1",
@@ -682,14 +689,15 @@ func TestMakeProxies(t *testing.T) {
 		want: []*v1.HTTPProxy{{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: "foo",
-				Name:      "bar-example.com",
+				Name:      "bar-" + publicClass + "-example.com",
 				Labels: map[string]string{
 					DomainHashKey: "0caaf24ab1a0c33440c06afe99df986365b0781f",
 					GenerationKey: "0",
 					ParentKey:     "bar",
+					ClassKey:      publicClass,
 				},
 				Annotations: map[string]string{
-					"projectcontour.io/ingress.class": publicClass,
+					ClassKey: publicClass,
 				},
 				OwnerReferences: []metav1.OwnerReference{{
 					APIVersion:         "networking.internal.knative.dev/v1alpha1",


### PR DESCRIPTION
The net-contour logic for translating kingress to httpproxy resources is a one-to-many
translation.  In fact, the arity of the http proxies can *change* dynamically over the
lifetime of a kingress.  So the logic to query, create, update, and delete httpproxy
resources is heavily label based.

Based on how Knative creates kingress resources, I do not believe it is possible to hit
this problem today, but given how we recursively use kingress for endpoint probing,
combined with how Knative uses kingress to invoke us, we hit this interesting corner case.

Essentially, the logic as it exists today assumes that the tuple `(kingress name, domain)`
is enough to uniquely identify the httpproxy; however, if a single kingress exposes the
same domain at multiple visibilities then this is insufficient.  We need the tuple
`(kingress name, domain, visibility)`.

Generally this wasn't a problem before because the external domain `foo.bar.example.com`
went to one visibility, while the other domain `foo.bar.svc.cluster.local` went to the other.
However, for the endpoint probe kingress, we create a host per service so that our probing
confirms that every endpoint is available.  Given that knative exposes the service by both
`foo.bar.example.com` AND `foo.bar.svc.cluster.local` this created a problem where we would
attempt to create the same endpoint probe httpproxy differing only in visibility.

There are two aspects to the fix for this:
1. Incorporate the visibility (class) into the name of the http proxy.
2. Label the http proxies with visibility, and filter on visibility when choosing which
  pre-existing httpproxy to update.

Despite changing resource names, this should be rollout safe because it only affects the
endpoint probe resource, which is new, and that resource doesn't exist in the steady state.

Fixes: https://github.com/knative-sandbox/net-contour/issues/176