### PR TITLE
Avoid updates due to defaulting.

### DIFF
--- a/pkg/reconciler/contour/contour_test.go
+++ b/pkg/reconciler/contour/contour_test.go
@@ -232,24 +232,12 @@ func TestReconcile(t *testing.T) {
 		WantDeletes: []clientgotesting.DeleteActionImpl{{
 			Name: "name--ep",
 		}},
-		WantUpdates: []clientgotesting.UpdateActionImpl{{
-			Object: mustMakeProxies(t,
-				ing("name", "ns", withContour, withGeneration(0), withBasicSpec),
-				withNetworkHash("3e4b90d361f17fcf23b3b6b9678f68801c4def32a42446db62fe01301dee7508"),
-			)[0],
-		}},
 	}, {
 		Name: "steady state basic ingress (no probe)",
 		Key:  "ns/name",
 		Objects: append(append([]runtime.Object{
 			ing("name", "ns", withBasicSpec, withContour, makeItReady),
 		}, mustMakeProxies(t, ing("name", "ns", withBasicSpec, withContour))...), servicesAndEndpoints...),
-		WantUpdates: []clientgotesting.UpdateActionImpl{{
-			Object: mustMakeProxies(t,
-				ing("name", "ns", withContour, withGeneration(0), withBasicSpec),
-				withNetworkHash("3e4b90d361f17fcf23b3b6b9678f68801c4def32a42446db62fe01301dee7508"),
-			)[0],
-		}},
 	}, {
 		Name: "basic ingress changed",
 		Key:  "ns/name",
@@ -744,6 +732,7 @@ func withBasicSpec(i *v1alpha1.Ingress) {
 				}},
 			},
 		}},
+		Visibility: "ExternalIP",
 	}
 }
 
@@ -766,6 +755,7 @@ func withBasicSpec2(i *v1alpha1.Ingress) {
 				}},
 			},
 		}},
+		Visibility: "ExternalIP",
 	}
 }
 
@@ -788,6 +778,7 @@ func withMultiProxySpec(i *v1alpha1.Ingress) {
 				}},
 			},
 		}},
+		Visibility: "ExternalIP",
 	}
 }
 

--- a/pkg/reconciler/contour/resources/kingress.go
+++ b/pkg/reconciler/contour/resources/kingress.go
@@ -42,6 +42,9 @@ func MakeEndpointProbeIngress(ctx context.Context, ing *v1alpha1.Ingress, previo
 			}),
 			OwnerReferences: []metav1.OwnerReference{*kmeta.NewControllerRef(ing)},
 		},
+		Spec: v1alpha1.IngressSpec{
+			Visibility: ing.Spec.Visibility, // Copy the top-level visibility.
+		},
 	}
 
 	sns := ServiceNames(ctx, ing)
@@ -117,6 +120,7 @@ func MakeEndpointProbeIngress(ctx context.Context, ing *v1alpha1.Ingress, previo
 								ServiceNamespace: ing.Namespace,
 								ServicePort:      si.Port,
 							},
+							Percent: 100,
 						}},
 					}},
 				},

--- a/pkg/reconciler/contour/resources/kingress_test.go
+++ b/pkg/reconciler/contour/resources/kingress_test.go
@@ -61,6 +61,7 @@ func TestMakeEndpointProbeIngress(t *testing.T) {
 				Name:      "bar",
 			},
 			Spec: v1alpha1.IngressSpec{
+				Visibility: v1alpha1.IngressVisibilityExternalIP,
 				Rules: []v1alpha1.IngressRule{{
 					Hosts:      []string{"example.com"},
 					Visibility: v1alpha1.IngressVisibilityExternalIP,
@@ -110,6 +111,7 @@ func TestMakeEndpointProbeIngress(t *testing.T) {
 				}},
 			},
 			Spec: v1alpha1.IngressSpec{
+				Visibility: v1alpha1.IngressVisibilityExternalIP,
 				Rules: []v1alpha1.IngressRule{{
 					Hosts:      []string{"doo.bar.foo.net-contour.invalid"},
 					Visibility: v1alpha1.IngressVisibilityExternalIP,
@@ -121,6 +123,7 @@ func TestMakeEndpointProbeIngress(t *testing.T) {
 									ServiceName:      "doo",
 									ServicePort:      intstr.FromInt(124),
 								},
+								Percent: 100,
 							}},
 						}},
 					},
@@ -135,6 +138,7 @@ func TestMakeEndpointProbeIngress(t *testing.T) {
 									ServiceName:      "goo",
 									ServicePort:      intstr.FromInt(123),
 								},
+								Percent: 100,
 							}},
 						}},
 					},
@@ -151,6 +155,7 @@ func TestMakeEndpointProbeIngress(t *testing.T) {
 				Name:      "bar",
 			},
 			Spec: v1alpha1.IngressSpec{
+				Visibility: v1alpha1.IngressVisibilityExternalIP,
 				Rules: []v1alpha1.IngressRule{{
 					Hosts:      []string{network.GetServiceHostname("foo", "bar")},
 					Visibility: v1alpha1.IngressVisibilityExternalIP,
@@ -184,6 +189,7 @@ func TestMakeEndpointProbeIngress(t *testing.T) {
 				}},
 			},
 			Spec: v1alpha1.IngressSpec{
+				Visibility: v1alpha1.IngressVisibilityExternalIP,
 				Rules: []v1alpha1.IngressRule{{
 					Hosts:      []string{"goo.bar.foo.net-contour.invalid"},
 					Visibility: v1alpha1.IngressVisibilityExternalIP,
@@ -195,6 +201,7 @@ func TestMakeEndpointProbeIngress(t *testing.T) {
 									ServiceName:      "goo",
 									ServicePort:      intstr.FromInt(123),
 								},
+								Percent: 100,
 							}},
 						}},
 					},
@@ -209,6 +216,7 @@ func TestMakeEndpointProbeIngress(t *testing.T) {
 				Name:      "bar",
 			},
 			Spec: v1alpha1.IngressSpec{
+				Visibility: v1alpha1.IngressVisibilityExternalIP,
 				Rules: []v1alpha1.IngressRule{{
 					Hosts:      []string{"example.com"},
 					Visibility: v1alpha1.IngressVisibilityClusterLocal,
@@ -247,6 +255,7 @@ func TestMakeEndpointProbeIngress(t *testing.T) {
 				}},
 			},
 			Spec: v1alpha1.IngressSpec{
+				Visibility: v1alpha1.IngressVisibilityExternalIP,
 				Rules: []v1alpha1.IngressRule{{
 					Hosts:      []string{"goo.bar.foo.net-contour.invalid"},
 					Visibility: v1alpha1.IngressVisibilityClusterLocal,
@@ -258,6 +267,7 @@ func TestMakeEndpointProbeIngress(t *testing.T) {
 									ServiceName:      "goo",
 									ServicePort:      intstr.FromInt(123),
 								},
+								Percent: 100,
 							}},
 						}},
 					},
@@ -272,6 +282,7 @@ func TestMakeEndpointProbeIngress(t *testing.T) {
 				Name:      "bar",
 			},
 			Spec: v1alpha1.IngressSpec{
+				Visibility: v1alpha1.IngressVisibilityExternalIP,
 				Rules: []v1alpha1.IngressRule{{
 					Hosts:      []string{"example.com"},
 					Visibility: v1alpha1.IngressVisibilityExternalIP,
@@ -324,6 +335,7 @@ func TestMakeEndpointProbeIngress(t *testing.T) {
 				}},
 			},
 			Spec: v1alpha1.IngressSpec{
+				Visibility: v1alpha1.IngressVisibilityExternalIP,
 				Rules: []v1alpha1.IngressRule{{
 					Hosts:      []string{"goo.bar.foo.net-contour.invalid"},
 					Visibility: v1alpha1.IngressVisibilityExternalIP,
@@ -335,6 +347,7 @@ func TestMakeEndpointProbeIngress(t *testing.T) {
 									ServiceName:      "goo",
 									ServicePort:      intstr.FromInt(123),
 								},
+								Percent: 100,
 							}},
 						}},
 					},
@@ -349,6 +362,7 @@ func TestMakeEndpointProbeIngress(t *testing.T) {
 				Name:      "bar",
 			},
 			Spec: v1alpha1.IngressSpec{
+				Visibility: v1alpha1.IngressVisibilityExternalIP,
 				Rules: []v1alpha1.IngressRule{{
 					Hosts:      []string{"example.com"},
 					Visibility: v1alpha1.IngressVisibilityExternalIP,
@@ -464,6 +478,7 @@ func TestMakeEndpointProbeIngress(t *testing.T) {
 				}},
 			},
 			Spec: v1alpha1.IngressSpec{
+				Visibility: v1alpha1.IngressVisibilityExternalIP,
 				Rules: []v1alpha1.IngressRule{{
 					Hosts:      []string{"doo.bar.foo.net-contour.invalid"},
 					Visibility: v1alpha1.IngressVisibilityExternalIP,
@@ -475,6 +490,7 @@ func TestMakeEndpointProbeIngress(t *testing.T) {
 									ServiceName:      "doo",
 									ServicePort:      intstr.FromInt(124),
 								},
+								Percent: 100,
 							}},
 						}},
 					},
@@ -489,6 +505,7 @@ func TestMakeEndpointProbeIngress(t *testing.T) {
 									ServiceName:      "goo",
 									ServicePort:      intstr.FromInt(123),
 								},
+								Percent: 100,
 							}},
 						}},
 					},
@@ -503,6 +520,7 @@ func TestMakeEndpointProbeIngress(t *testing.T) {
 				Name:      "bar",
 			},
 			Spec: v1alpha1.IngressSpec{
+				Visibility: v1alpha1.IngressVisibilityExternalIP,
 				Rules: []v1alpha1.IngressRule{{
 					Hosts:      []string{"example.com"},
 					Visibility: v1alpha1.IngressVisibilityExternalIP,
@@ -627,6 +645,7 @@ func TestMakeEndpointProbeIngress(t *testing.T) {
 				}},
 			},
 			Spec: v1alpha1.IngressSpec{
+				Visibility: v1alpha1.IngressVisibilityExternalIP,
 				Rules: []v1alpha1.IngressRule{{
 					Hosts:      []string{"doo.bar.foo.net-contour.invalid"},
 					Visibility: v1alpha1.IngressVisibilityExternalIP,
@@ -638,6 +657,7 @@ func TestMakeEndpointProbeIngress(t *testing.T) {
 									ServiceName:      "doo",
 									ServicePort:      intstr.FromInt(124),
 								},
+								Percent: 100,
 							}},
 						}},
 					},
@@ -652,6 +672,7 @@ func TestMakeEndpointProbeIngress(t *testing.T) {
 									ServiceName:      "fu",
 									ServicePort:      intstr.FromInt(124),
 								},
+								Percent: 100,
 							}},
 						}},
 					},
@@ -666,6 +687,7 @@ func TestMakeEndpointProbeIngress(t *testing.T) {
 									ServiceName:      "goo",
 									ServicePort:      intstr.FromInt(123),
 								},
+								Percent: 100,
 							}},
 						}},
 					},
@@ -680,6 +702,7 @@ func TestMakeEndpointProbeIngress(t *testing.T) {
 									ServiceName:      "kung",
 									ServicePort:      intstr.FromInt(123),
 								},
+								Percent: 100,
 							}},
 						}},
 					},


### PR DESCRIPTION
We have a bit of log churn from updates that end up being nops due to defaulting.  This fills in default values to avoid the API and log churn.