### PR TITLE
Prefer nil over empty list in LoadBalancer field

### DIFF
--- a/pkg/reconciler/contour/contour.go
+++ b/pkg/reconciler/contour/contour.go
@@ -243,7 +243,7 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, ing *v1alpha1.Ingress) r
 	logger.Debugf("Status prober returned %v.", ready)
 	if ready {
 		ing.Status.MarkLoadBalancerReady(
-			[]v1alpha1.LoadBalancerIngressStatus{},
+			nil,
 			lbStatus(ctx, v1alpha1.IngressVisibilityExternalIP),
 			lbStatus(ctx, v1alpha1.IngressVisibilityClusterLocal))
 


### PR DESCRIPTION
I saw this in the logs of a failure on another PR:
```
Updating status with:   v1alpha1.IngressStatus{
          	Status: v1.Status{
          		ObservedGeneration: 2,
          		Conditions: v1.Conditions{
          			{
          				Type:               "LoadBalancerReady",
          				Status:             "True",
          				Severity:           "",
        - 				LastTransitionTime: apis.VolatileTime{Inner: v1.Time{Time: s"2020-08-11 16:30:03 +0000 UTC"}},
        + 				LastTransitionTime: apis.VolatileTime{
        + 					Inner: v1.Time{Time: s"2020-08-11 16:30:13.885296136 +0000 UTC m=+166.655645936"},
        + 				},
          				Reason:  "",
          				Message: "",
          			},
          			{Type: "NetworkConfigured", Status: "True", LastTransitionTime: {Inner: {Time: s"2020-08-11 16:29:39 +0000 UTC"}}},
          			{
          				Type:               "Ready",
          				Status:             "True",
          				Severity:           "",
        - 				LastTransitionTime: apis.VolatileTime{Inner: v1.Time{Time: s"2020-08-11 16:30:12 +0000 UTC"}},
        + 				LastTransitionTime: apis.VolatileTime{
        + 					Inner: v1.Time{Time: s"2020-08-11 16:30:13.885296136 +0000 UTC m=+166.655645936"},
        + 				},
          				Reason:  "",
          				Message: "",
          			},
          		},
          		Annotations: nil,
          	},
        - 	LoadBalancer:        &v1alpha1.LoadBalancerStatus{},
        + 	LoadBalancer:        &v1alpha1.LoadBalancerStatus{Ingress: []v1alpha1.LoadBalancerIngressStatus{}},
          	PublicLoadBalancer:  &{Ingress: {{DomainInternal: "envoy.contour-external.svc.cluster.local"}}},
          	PrivateLoadBalancer: &{Ingress: {{DomainInternal: "envoy.contour-internal.svc.cluster.local"}}},
          }
```

It actually had a fair number of status updates that looked like this, which is very undesirable.