### PR TITLE
Plumb through RewriteHost in the obvious way.

### DIFF
--- a/pkg/reconciler/contour/resources/httpproxy.go
+++ b/pkg/reconciler/contour/resources/httpproxy.go
@@ -139,6 +139,14 @@ func MakeHTTPProxies(ctx context.Context, ing *v1alpha1.Ingress, serviceToProtoc
 					Value: value,
 				})
 			}
+
+			if path.RewriteHost != "" {
+				preSplitHeaders.Set = append(preSplitHeaders.Set, v1.HeaderValue{
+					Name:  "Host",
+					Value: path.RewriteHost,
+				})
+			}
+
 			// This should never be empty due to the InsertProbe
 			sort.Slice(preSplitHeaders.Set, func(i, j int) bool {
 				return preSplitHeaders.Set[i].Name < preSplitHeaders.Set[j].Name


### PR DESCRIPTION
This adds the ~6 LoC I'd have expected to implement RewriteHost,
but it DOES NOT pass the host-rewrite test because things are complicated.
The shape of things that this actually works for isn't actually supported
by kingress today because RewriteHost cannot occur alongside Splits, and
the host that the kingress rewrites to is expected to be re-evaluated
against the cluster-local kingress rules.  This obviously doesn't do all of
that, but I have verified that this works if the kingress webhook is relaxed
and the rewrite-host test is simplified to use a single-level kingress.

The reason for the non-intuitive definition of RewriteHost that exists in
kingress today stems from an inability to easily compose kingress resources
due to the inability to compose the elements that implement the dataplane
contract.  I have a proposal [here](https://github.com/knative/serving/issues/9074)
to try and enable composition of kingress, which would enable us to to use
the intuitive definition of RewriteHost.

Related, but incomplete until we rework the definition of RewriteHost:
https://github.com/knative-sandbox/net-contour/issues/211