### PR TITLE
Avoid thundering herd of probes during failover.

### DIFF
--- a/pkg/reconciler/contour/contour.go
+++ b/pkg/reconciler/contour/contour.go
@@ -142,6 +142,8 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, ing *v1alpha1.Ingress) r
 		}
 
 		if !actualChIng.IsReady() {
+			// This won't be toggled back until probing has completed.
+			ing.Status.MarkLoadBalancerNotReady()
 			ing.Status.MarkIngressNotReady("EndpointsNotReady", "Waiting for Envoys to receive Endpoints data.")
 			return nil
 		}

--- a/pkg/reconciler/contour/contour.go
+++ b/pkg/reconciler/contour/contour.go
@@ -246,27 +246,49 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, ing *v1alpha1.Ingress) r
 	}
 	ing.Status.MarkNetworkConfigured()
 
-	ready, err := r.statusManager.IsReady(ctx, ing)
-	if err != nil {
-		return fmt.Errorf("failed to probe Ingress %s/%s: %w", ing.GetNamespace(), ing.GetName(), err)
+	if ing.IsReady() {
+		// When the kingress has already been marked Ready for this generation,
+		// then it must have been successfully probed.  The status manager has
+		// caching built-in, which makes this exception unnecessary for the case
+		// of global resyncs.  HOWEVER, that caching doesn't help at all for
+		// the failover case (cold caches), and the initial sync turns into a
+		// thundering herd.
+		// As this is an optimization, we don't worry about the ObservedGeneration
+		// skew we might see when the resource is actually in flux, we simply care
+		// about the steady state.
+		logger.Debug("kingress is ready, skipping probe.")
+	} else {
+		ready, err := r.statusManager.IsReady(ctx, ing)
+		if err != nil {
+			return fmt.Errorf("failed to probe Ingress %s/%s: %w", ing.GetNamespace(), ing.GetName(), err)
+		}
+		logger.Debugf("Status prober returned %v.", ready)
+		if ready {
+			ing.Status.MarkLoadBalancerReady(
+				nil,
+				lbStatus(ctx, v1alpha1.IngressVisibilityExternalIP),
+				lbStatus(ctx, v1alpha1.IngressVisibilityClusterLocal))
+		} else {
+			ing.Status.MarkLoadBalancerNotReady()
+		}
 	}
-	logger.Debugf("Status prober returned %v.", ready)
-	if ready {
-		ing.Status.MarkLoadBalancerReady(
-			nil,
-			lbStatus(ctx, v1alpha1.IngressVisibilityExternalIP),
-			lbStatus(ctx, v1alpha1.IngressVisibilityClusterLocal))
 
-		if haveEndpointProbe {
+	// Having fully reflected our status, set this before checking
+	// readiness below for deletion.
+	ing.Status.ObservedGeneration = ing.Generation
+
+	// Check whether it is safe to remove the endpoint probe.
+	if haveEndpointProbe {
+		if ing.IsReady() {
 			// Delete the endpoints probe once we have reached a steady state.
 			if err := r.ingressClient.NetworkingV1alpha1().Ingresses(ing.Namespace).Delete(
 				names.EndpointProbeIngress(ing), &metav1.DeleteOptions{}); err != nil {
 				return err
 			}
 			logger.Debug("Deleted endpoint probe.")
+		} else {
+			logger.Debug("Keeping endpoint probe, not ready.")
 		}
-	} else {
-		ing.Status.MarkLoadBalancerNotReady()
 	}
 	return nil
 }

--- a/pkg/reconciler/contour/contour_test.go
+++ b/pkg/reconciler/contour/contour_test.go
@@ -89,6 +89,7 @@ func TestReconcile(t *testing.T) {
 			Object: ing("name", "ns", withBasicSpec, withContour, func(i *v1alpha1.Ingress) {
 				// These are the things we expect to change in status.
 				i.Status.InitializeConditions()
+				i.Status.MarkLoadBalancerNotReady()
 				i.Status.MarkIngressNotReady("EndpointsNotReady", "Waiting for Envoys to receive Endpoints data.")
 			}),
 		}},
@@ -178,6 +179,7 @@ func TestReconcile(t *testing.T) {
 			ing("name", "ns", withBasicSpec, withContour, func(i *v1alpha1.Ingress) {
 				// These are the things we expect to change in status.
 				i.Status.InitializeConditions()
+				i.Status.MarkLoadBalancerNotReady()
 				i.Status.MarkIngressNotReady("EndpointsNotReady", "Waiting for Envoys to receive Endpoints data.")
 			}),
 			mustMakeProbe(t, ing("name", "ns", withBasicSpec, withContour)),
@@ -196,6 +198,7 @@ func TestReconcile(t *testing.T) {
 			Object: ing("name", "ns", withBasicSpec, withContour, func(i *v1alpha1.Ingress) {
 				// These are the things we expect to change in status.
 				i.Status.InitializeConditions()
+				i.Status.MarkLoadBalancerNotReady()
 				i.Status.MarkIngressNotReady("EndpointsNotReady", "Waiting for Envoys to receive Endpoints data.")
 			}),
 		}},


### PR DESCRIPTION
This change guards the status prober with a simple readiness check as an
optimization for the case of failing over and globally resyncing resources.
When a fresh controller pod slurps through ~100 kingress for the first time
we will currently probe ALL of them.  On a 10 Node cluster, with 1 public and
3 private hostnames, this works out to a lot of probes:

```
  100 * (1 * 10 + 3 * 10) = 4000
```

Factor in what we do with endpoint probing, and it adds roughly 2000 probes.

Currently, this is what the scale-100 test in serving is doing every 30s or so,
in addition to the standard work it is doing.

Fixes: https://github.com/knative-sandbox/net-contour/issues/203

Possibly related to: https://github.com/knative-sandbox/net-contour/issues/226