### PR TITLE
Adjust the default RetryOn policy.

### DIFF
--- a/pkg/reconciler/contour/resources/httpproxy.go
+++ b/pkg/reconciler/contour/resources/httpproxy.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"crypto/sha1"
 	"fmt"
+	"net/http"
 	"sort"
 	"strings"
 
@@ -76,6 +77,26 @@ func ServiceNames(ctx context.Context, ing *v1alpha1.Ingress) map[string]Service
 	return s
 }
 
+func defaultRetryPolicy() *v1.RetryPolicy {
+	return &v1.RetryPolicy{
+		NumRetries: 2,
+		RetryOn: []v1.RetryOn{
+			"cancelled",
+			"connect-failure",
+			"refused-stream",
+			"resource-exhausted",
+			"retriable-status-codes",
+
+			// In addition to what Istio specifies (above),
+			// also retry connection resets.
+			"reset",
+		},
+		RetriableStatusCodes: []uint32{
+			http.StatusServiceUnavailable,
+		},
+	}
+}
+
 func MakeHTTPProxies(ctx context.Context, ing *v1alpha1.Ingress, serviceToProtocol map[string]string) []*v1.HTTPProxy {
 	ing = ing.DeepCopy()
 	ingress.InsertProbe(ing)
@@ -116,20 +137,13 @@ func MakeHTTPProxies(ctx context.Context, ing *v1alpha1.Ingress, serviceToProtoc
 			// By default retry on connection problems twice.
 			// This matches the default behavior of Istio:
 			// https://istio.io/latest/docs/concepts/traffic-management/#retries
-			retry := &v1.RetryPolicy{
-				NumRetries: 2,
-				RetryOn: []v1.RetryOn{
-					"connect-failure",
-					"refused-stream",
-					"cancelled",
-					"resource-exhausted",
-				},
-			}
+			// However, in addition to the codes specified by istio
+			retry := defaultRetryPolicy()
 			if path.DeprecatedRetries != nil && path.DeprecatedRetries.Attempts > 0 {
 				retry.NumRetries = int64(path.DeprecatedRetries.Attempts)
 
 				// When retries is specified explicitly, then we retry some http-level failures as well.
-				retry.RetryOn = append(retry.RetryOn, "retriable-status-codes", "5xx")
+				retry.RetryOn = append(retry.RetryOn, "5xx")
 
 				if path.DeprecatedRetries.PerTryTimeout != nil {
 					retry.PerTryTimeout = path.DeprecatedRetries.PerTryTimeout.Duration.String()

--- a/pkg/reconciler/contour/resources/httpproxy_test.go
+++ b/pkg/reconciler/contour/resources/httpproxy_test.go
@@ -18,6 +18,7 @@ package resources
 
 import (
 	"context"
+	"net/http"
 	"testing"
 	"time"
 
@@ -124,15 +125,7 @@ func TestMakeProxies(t *testing.T) {
 					TimeoutPolicy: &v1.TimeoutPolicy{
 						Response: "infinity",
 					},
-					RetryPolicy: &v1.RetryPolicy{
-						NumRetries: 2,
-						RetryOn: []v1.RetryOn{
-							"connect-failure",
-							"refused-stream",
-							"cancelled",
-							"resource-exhausted",
-						},
-					},
+					RetryPolicy: defaultRetryPolicy(),
 					Conditions: []v1.MatchCondition{{
 						Header: &v1.HeaderMatchCondition{
 							Name:  "K-Network-Hash",
@@ -179,15 +172,7 @@ func TestMakeProxies(t *testing.T) {
 					TimeoutPolicy: &v1.TimeoutPolicy{
 						Response: "infinity",
 					},
-					RetryPolicy: &v1.RetryPolicy{
-						NumRetries: 2,
-						RetryOn: []v1.RetryOn{
-							"connect-failure",
-							"refused-stream",
-							"cancelled",
-							"resource-exhausted",
-						},
-					},
+					RetryPolicy: defaultRetryPolicy(),
 					RequestHeadersPolicy: &v1.HeadersPolicy{
 						Set: []v1.HeaderValue{{
 							Name:  "Foo",
@@ -280,15 +265,7 @@ func TestMakeProxies(t *testing.T) {
 					TimeoutPolicy: &v1.TimeoutPolicy{
 						Response: "infinity",
 					},
-					RetryPolicy: &v1.RetryPolicy{
-						NumRetries: 2,
-						RetryOn: []v1.RetryOn{
-							"connect-failure",
-							"refused-stream",
-							"cancelled",
-							"resource-exhausted",
-						},
-					},
+					RetryPolicy: defaultRetryPolicy(),
 					Conditions: []v1.MatchCondition{{
 						Header: &v1.HeaderMatchCondition{
 							Name:  "K-Network-Hash",
@@ -313,15 +290,7 @@ func TestMakeProxies(t *testing.T) {
 					TimeoutPolicy: &v1.TimeoutPolicy{
 						Response: "infinity",
 					},
-					RetryPolicy: &v1.RetryPolicy{
-						NumRetries: 2,
-						RetryOn: []v1.RetryOn{
-							"connect-failure",
-							"refused-stream",
-							"cancelled",
-							"resource-exhausted",
-						},
-					},
+					RetryPolicy: defaultRetryPolicy(),
 					RequestHeadersPolicy: &v1.HeadersPolicy{
 						Set: []v1.HeaderValue{},
 					},
@@ -364,15 +333,7 @@ func TestMakeProxies(t *testing.T) {
 					TimeoutPolicy: &v1.TimeoutPolicy{
 						Response: "infinity",
 					},
-					RetryPolicy: &v1.RetryPolicy{
-						NumRetries: 2,
-						RetryOn: []v1.RetryOn{
-							"connect-failure",
-							"refused-stream",
-							"cancelled",
-							"resource-exhausted",
-						},
-					},
+					RetryPolicy: defaultRetryPolicy(),
 					Conditions: []v1.MatchCondition{{
 						Header: &v1.HeaderMatchCondition{
 							Name:  "K-Network-Hash",
@@ -397,15 +358,7 @@ func TestMakeProxies(t *testing.T) {
 					TimeoutPolicy: &v1.TimeoutPolicy{
 						Response: "infinity",
 					},
-					RetryPolicy: &v1.RetryPolicy{
-						NumRetries: 2,
-						RetryOn: []v1.RetryOn{
-							"connect-failure",
-							"refused-stream",
-							"cancelled",
-							"resource-exhausted",
-						},
-					},
+					RetryPolicy: defaultRetryPolicy(),
 					RequestHeadersPolicy: &v1.HeadersPolicy{
 						Set: []v1.HeaderValue{},
 					},
@@ -448,15 +401,7 @@ func TestMakeProxies(t *testing.T) {
 					TimeoutPolicy: &v1.TimeoutPolicy{
 						Response: "infinity",
 					},
-					RetryPolicy: &v1.RetryPolicy{
-						NumRetries: 2,
-						RetryOn: []v1.RetryOn{
-							"connect-failure",
-							"refused-stream",
-							"cancelled",
-							"resource-exhausted",
-						},
-					},
+					RetryPolicy: defaultRetryPolicy(),
 					Conditions: []v1.MatchCondition{{
 						Header: &v1.HeaderMatchCondition{
 							Name:  "K-Network-Hash",
@@ -481,15 +426,7 @@ func TestMakeProxies(t *testing.T) {
 					TimeoutPolicy: &v1.TimeoutPolicy{
 						Response: "infinity",
 					},
-					RetryPolicy: &v1.RetryPolicy{
-						NumRetries: 2,
-						RetryOn: []v1.RetryOn{
-							"connect-failure",
-							"refused-stream",
-							"cancelled",
-							"resource-exhausted",
-						},
-					},
+					RetryPolicy: defaultRetryPolicy(),
 					RequestHeadersPolicy: &v1.HeadersPolicy{
 						Set: []v1.HeaderValue{},
 					},
@@ -564,12 +501,16 @@ func TestMakeProxies(t *testing.T) {
 						NumRetries:    34,
 						PerTryTimeout: "14m0s",
 						RetryOn: []v1.RetryOn{
+							"cancelled",
 							"connect-failure",
 							"refused-stream",
-							"cancelled",
 							"resource-exhausted",
 							"retriable-status-codes",
+							"reset",
 							"5xx",
+						},
+						RetriableStatusCodes: []uint32{
+							http.StatusServiceUnavailable,
 						},
 					},
 					TimeoutPolicy: &v1.TimeoutPolicy{
@@ -600,12 +541,16 @@ func TestMakeProxies(t *testing.T) {
 						NumRetries:    34,
 						PerTryTimeout: "14m0s",
 						RetryOn: []v1.RetryOn{
+							"cancelled",
 							"connect-failure",
 							"refused-stream",
-							"cancelled",
 							"resource-exhausted",
 							"retriable-status-codes",
+							"reset",
 							"5xx",
+						},
+						RetriableStatusCodes: []uint32{
+							http.StatusServiceUnavailable,
 						},
 					},
 					TimeoutPolicy: &v1.TimeoutPolicy{
@@ -712,15 +657,7 @@ func TestMakeProxies(t *testing.T) {
 					TimeoutPolicy: &v1.TimeoutPolicy{
 						Response: "infinity",
 					},
-					RetryPolicy: &v1.RetryPolicy{
-						NumRetries: 2,
-						RetryOn: []v1.RetryOn{
-							"connect-failure",
-							"refused-stream",
-							"cancelled",
-							"resource-exhausted",
-						},
-					},
+					RetryPolicy: defaultRetryPolicy(),
 					RequestHeadersPolicy: &v1.HeadersPolicy{
 						Set: []v1.HeaderValue{{
 							Name:  "K-Network-Hash",
@@ -752,15 +689,7 @@ func TestMakeProxies(t *testing.T) {
 					TimeoutPolicy: &v1.TimeoutPolicy{
 						Response: "infinity",
 					},
-					RetryPolicy: &v1.RetryPolicy{
-						NumRetries: 2,
-						RetryOn: []v1.RetryOn{
-							"connect-failure",
-							"refused-stream",
-							"cancelled",
-							"resource-exhausted",
-						},
-					},
+					RetryPolicy: defaultRetryPolicy(),
 					RequestHeadersPolicy: &v1.HeadersPolicy{
 						Set: []v1.HeaderValue{{
 							Name:  "K-Network-Hash",
@@ -786,15 +715,7 @@ func TestMakeProxies(t *testing.T) {
 					TimeoutPolicy: &v1.TimeoutPolicy{
 						Response: "infinity",
 					},
-					RetryPolicy: &v1.RetryPolicy{
-						NumRetries: 2,
-						RetryOn: []v1.RetryOn{
-							"connect-failure",
-							"refused-stream",
-							"cancelled",
-							"resource-exhausted",
-						},
-					},
+					RetryPolicy: defaultRetryPolicy(),
 					RequestHeadersPolicy: &v1.HeadersPolicy{
 						Set: []v1.HeaderValue{},
 					},
@@ -818,15 +739,7 @@ func TestMakeProxies(t *testing.T) {
 					TimeoutPolicy: &v1.TimeoutPolicy{
 						Response: "infinity",
 					},
-					RetryPolicy: &v1.RetryPolicy{
-						NumRetries: 2,
-						RetryOn: []v1.RetryOn{
-							"connect-failure",
-							"refused-stream",
-							"cancelled",
-							"resource-exhausted",
-						},
-					},
+					RetryPolicy: defaultRetryPolicy(),
 					RequestHeadersPolicy: &v1.HeadersPolicy{
 						Set: []v1.HeaderValue{},
 					},
@@ -918,15 +831,7 @@ func TestMakeProxies(t *testing.T) {
 					TimeoutPolicy: &v1.TimeoutPolicy{
 						Response: "infinity",
 					},
-					RetryPolicy: &v1.RetryPolicy{
-						NumRetries: 2,
-						RetryOn: []v1.RetryOn{
-							"connect-failure",
-							"refused-stream",
-							"cancelled",
-							"resource-exhausted",
-						},
-					},
+					RetryPolicy: defaultRetryPolicy(),
 					Conditions: []v1.MatchCondition{{
 						Header: &v1.HeaderMatchCondition{
 							Name:  "K-Network-Hash",
@@ -970,15 +875,7 @@ func TestMakeProxies(t *testing.T) {
 					TimeoutPolicy: &v1.TimeoutPolicy{
 						Response: "infinity",
 					},
-					RetryPolicy: &v1.RetryPolicy{
-						NumRetries: 2,
-						RetryOn: []v1.RetryOn{
-							"connect-failure",
-							"refused-stream",
-							"cancelled",
-							"resource-exhausted",
-						},
-					},
+					RetryPolicy: defaultRetryPolicy(),
 					RequestHeadersPolicy: &v1.HeadersPolicy{
 						Set: []v1.HeaderValue{{
 							Name:  "Foo",
@@ -1090,15 +987,7 @@ func TestMakeProxies(t *testing.T) {
 					TimeoutPolicy: &v1.TimeoutPolicy{
 						Response: "infinity",
 					},
-					RetryPolicy: &v1.RetryPolicy{
-						NumRetries: 2,
-						RetryOn: []v1.RetryOn{
-							"connect-failure",
-							"refused-stream",
-							"cancelled",
-							"resource-exhausted",
-						},
-					},
+					RetryPolicy: defaultRetryPolicy(),
 					Conditions: []v1.MatchCondition{{
 						Header: &v1.HeaderMatchCondition{
 							Name:  "K-Network-Hash",
@@ -1142,15 +1031,7 @@ func TestMakeProxies(t *testing.T) {
 					TimeoutPolicy: &v1.TimeoutPolicy{
 						Response: "infinity",
 					},
-					RetryPolicy: &v1.RetryPolicy{
-						NumRetries: 2,
-						RetryOn: []v1.RetryOn{
-							"connect-failure",
-							"refused-stream",
-							"cancelled",
-							"resource-exhausted",
-						},
-					},
+					RetryPolicy: defaultRetryPolicy(),
 					RequestHeadersPolicy: &v1.HeadersPolicy{
 						Set: []v1.HeaderValue{{
 							Name:  "Foo",
@@ -1250,15 +1131,7 @@ func TestMakeProxies(t *testing.T) {
 					TimeoutPolicy: &v1.TimeoutPolicy{
 						Response: "infinity",
 					},
-					RetryPolicy: &v1.RetryPolicy{
-						NumRetries: 2,
-						RetryOn: []v1.RetryOn{
-							"connect-failure",
-							"refused-stream",
-							"cancelled",
-							"resource-exhausted",
-						},
-					},
+					RetryPolicy: defaultRetryPolicy(),
 					Conditions: []v1.MatchCondition{{
 						Header: &v1.HeaderMatchCondition{
 							Name:  "K-Network-Hash",
@@ -1289,15 +1162,7 @@ func TestMakeProxies(t *testing.T) {
 					TimeoutPolicy: &v1.TimeoutPolicy{
 						Response: "infinity",
 					},
-					RetryPolicy: &v1.RetryPolicy{
-						NumRetries: 2,
-						RetryOn: []v1.RetryOn{
-							"connect-failure",
-							"refused-stream",
-							"cancelled",
-							"resource-exhausted",
-						},
-					},
+					RetryPolicy: defaultRetryPolicy(),
 					RequestHeadersPolicy: &v1.HeadersPolicy{
 						Set: []v1.HeaderValue{},
 					},
@@ -1376,15 +1241,7 @@ func TestMakeProxies(t *testing.T) {
 					TimeoutPolicy: &v1.TimeoutPolicy{
 						Response: "infinity",
 					},
-					RetryPolicy: &v1.RetryPolicy{
-						NumRetries: 2,
-						RetryOn: []v1.RetryOn{
-							"connect-failure",
-							"refused-stream",
-							"cancelled",
-							"resource-exhausted",
-						},
-					},
+					RetryPolicy: defaultRetryPolicy(),
 					Conditions: []v1.MatchCondition{{
 						Header: &v1.HeaderMatchCondition{
 							Name:  "K-Network-Hash",
@@ -1418,15 +1275,7 @@ func TestMakeProxies(t *testing.T) {
 					TimeoutPolicy: &v1.TimeoutPolicy{
 						Response: "infinity",
 					},
-					RetryPolicy: &v1.RetryPolicy{
-						NumRetries: 2,
-						RetryOn: []v1.RetryOn{
-							"connect-failure",
-							"refused-stream",
-							"cancelled",
-							"resource-exhausted",
-						},
-					},
+					RetryPolicy: defaultRetryPolicy(),
 					RequestHeadersPolicy: &v1.HeadersPolicy{
 						Set: []v1.HeaderValue{{
 							Name:  "Host",


### PR DESCRIPTION
This adjusts the default retry policy to more correctly match Istio's, and add one new kind of retry that Istio does not seem to do: `reset`.

WRT "more correctly" matching Istio, the bug was copied from `net-istio`, which supplied `retriable-status-codes`, but not a list of codes that are actually retriable!  Looking at the actual Istio code, it seems to be retrying 503s using this mechanism: https://github.com/istio/istio/blob/748c6209f606fb2276bdd4abaf277d4979d172bc/pilot/pkg/networking/core/v1alpha3/route/retry/retry.go#L39

I suspect that this is the remaining delta to resolve the connection reset errors that pop up intermittently with net-contour, but not net-istio...

Fixes: https://github.com/knative-sandbox/net-contour/issues/237