### PR TITLE
Ensure that endpoint probes avoid hostname collisions.

### DIFF
--- a/pkg/reconciler/contour/contour_test.go
+++ b/pkg/reconciler/contour/contour_test.go
@@ -256,7 +256,7 @@ func TestReconcile(t *testing.T) {
 		Key:  "ns/name",
 		Objects: append(append([]runtime.Object{
 			ing("name", "ns", withContour, withGeneration(1), withBasicSpec2),
-			mustMakeProbe(t, ing("name", "ns", withBasicSpec2, withContour), makeItReady),
+			mustMakeProbe(t, ing("name", "ns", withBasicSpec2, withContour, withGeneration(1)), makeItReady),
 		}, mustMakeProxies(t, ing("name", "ns", withBasicSpec, withContour))...), servicesAndEndpoints...),
 		WantUpdates: []clientgotesting.UpdateActionImpl{{
 			Object: mustMakeProxies(t,
@@ -354,7 +354,7 @@ func TestReconcile(t *testing.T) {
 		},
 		Objects: append(append([]runtime.Object{
 			ing("name", "ns", withContour, withGeneration(1), withBasicSpec2),
-			mustMakeProbe(t, ing("name", "ns", withBasicSpec2, withContour), makeItReady),
+			mustMakeProbe(t, ing("name", "ns", withBasicSpec2, withContour, withGeneration(1)), makeItReady),
 		}, mustMakeProxies(t, ing("name", "ns", withBasicSpec, withContour))...), servicesAndEndpoints...),
 		WantUpdates: []clientgotesting.UpdateActionImpl{{
 			Object: mustMakeProxies(t,
@@ -381,7 +381,7 @@ func TestReconcile(t *testing.T) {
 		},
 		Objects: append(append([]runtime.Object{
 			ing("name", "ns", withContour, withGeneration(1), withBasicSpec2),
-			mustMakeProbe(t, ing("name", "ns", withBasicSpec2, withContour), makeItReady),
+			mustMakeProbe(t, ing("name", "ns", withBasicSpec2, withContour, withGeneration(1)), makeItReady),
 		}, mustMakeProxies(t, ing("name", "ns", withBasicSpec, withContour))...), servicesAndEndpoints...),
 		WantUpdates: []clientgotesting.UpdateActionImpl{{
 			Object: mustMakeProxies(t,

--- a/pkg/reconciler/contour/resources/kingress.go
+++ b/pkg/reconciler/contour/resources/kingress.go
@@ -101,7 +101,7 @@ func MakeEndpointProbeIngress(ctx context.Context, ing *v1alpha1.Ingress, previo
 		}
 		for _, vis := range si.Visibilities() {
 			childIng.Spec.Rules = append(childIng.Spec.Rules, v1alpha1.IngressRule{
-				Hosts:      []string{fmt.Sprintf("%s.%s.%s.net-contour.invalid", name, ing.Name, ing.Namespace)},
+				Hosts:      []string{fmt.Sprintf("%s.gen-%d.%s.%s.net-contour.invalid", name, ing.Generation, ing.Name, ing.Namespace)},
 				Visibility: vis,
 				HTTP: &v1alpha1.HTTPIngressRuleValue{
 					Paths: []v1alpha1.HTTPIngressPath{{

--- a/pkg/reconciler/contour/resources/kingress_test.go
+++ b/pkg/reconciler/contour/resources/kingress_test.go
@@ -57,8 +57,9 @@ func TestMakeEndpointProbeIngress(t *testing.T) {
 		name: "single external domain with split (no prev)",
 		ing: &v1alpha1.Ingress{
 			ObjectMeta: metav1.ObjectMeta{
-				Namespace: "foo",
-				Name:      "bar",
+				Namespace:  "foo",
+				Name:       "bar",
+				Generation: 123,
 			},
 			Spec: v1alpha1.IngressSpec{
 				DeprecatedVisibility: v1alpha1.IngressVisibilityExternalIP,
@@ -113,7 +114,7 @@ func TestMakeEndpointProbeIngress(t *testing.T) {
 			Spec: v1alpha1.IngressSpec{
 				DeprecatedVisibility: v1alpha1.IngressVisibilityExternalIP,
 				Rules: []v1alpha1.IngressRule{{
-					Hosts:      []string{"doo.bar.foo.net-contour.invalid"},
+					Hosts:      []string{"doo.gen-123.bar.foo.net-contour.invalid"},
 					Visibility: v1alpha1.IngressVisibilityExternalIP,
 					HTTP: &v1alpha1.HTTPIngressRuleValue{
 						Paths: []v1alpha1.HTTPIngressPath{{
@@ -128,7 +129,7 @@ func TestMakeEndpointProbeIngress(t *testing.T) {
 						}},
 					},
 				}, {
-					Hosts:      []string{"goo.bar.foo.net-contour.invalid"},
+					Hosts:      []string{"goo.gen-123.bar.foo.net-contour.invalid"},
 					Visibility: v1alpha1.IngressVisibilityExternalIP,
 					HTTP: &v1alpha1.HTTPIngressRuleValue{
 						Paths: []v1alpha1.HTTPIngressPath{{
@@ -151,8 +152,9 @@ func TestMakeEndpointProbeIngress(t *testing.T) {
 		name: "external visibility with internal domain",
 		ing: &v1alpha1.Ingress{
 			ObjectMeta: metav1.ObjectMeta{
-				Namespace: "foo",
-				Name:      "bar",
+				Namespace:  "foo",
+				Name:       "bar",
+				Generation: 432,
 			},
 			Spec: v1alpha1.IngressSpec{
 				DeprecatedVisibility: v1alpha1.IngressVisibilityExternalIP,
@@ -191,7 +193,7 @@ func TestMakeEndpointProbeIngress(t *testing.T) {
 			Spec: v1alpha1.IngressSpec{
 				DeprecatedVisibility: v1alpha1.IngressVisibilityExternalIP,
 				Rules: []v1alpha1.IngressRule{{
-					Hosts:      []string{"goo.bar.foo.net-contour.invalid"},
+					Hosts:      []string{"goo.gen-432.bar.foo.net-contour.invalid"},
 					Visibility: v1alpha1.IngressVisibilityExternalIP,
 					HTTP: &v1alpha1.HTTPIngressRuleValue{
 						Paths: []v1alpha1.HTTPIngressPath{{
@@ -257,7 +259,7 @@ func TestMakeEndpointProbeIngress(t *testing.T) {
 			Spec: v1alpha1.IngressSpec{
 				DeprecatedVisibility: v1alpha1.IngressVisibilityExternalIP,
 				Rules: []v1alpha1.IngressRule{{
-					Hosts:      []string{"goo.bar.foo.net-contour.invalid"},
+					Hosts:      []string{"goo.gen-0.bar.foo.net-contour.invalid"},
 					Visibility: v1alpha1.IngressVisibilityClusterLocal,
 					HTTP: &v1alpha1.HTTPIngressRuleValue{
 						Paths: []v1alpha1.HTTPIngressPath{{
@@ -337,7 +339,7 @@ func TestMakeEndpointProbeIngress(t *testing.T) {
 			Spec: v1alpha1.IngressSpec{
 				DeprecatedVisibility: v1alpha1.IngressVisibilityExternalIP,
 				Rules: []v1alpha1.IngressRule{{
-					Hosts:      []string{"goo.bar.foo.net-contour.invalid"},
+					Hosts:      []string{"goo.gen-0.bar.foo.net-contour.invalid"},
 					Visibility: v1alpha1.IngressVisibilityExternalIP,
 					HTTP: &v1alpha1.HTTPIngressRuleValue{
 						Paths: []v1alpha1.HTTPIngressPath{{
@@ -480,7 +482,7 @@ func TestMakeEndpointProbeIngress(t *testing.T) {
 			Spec: v1alpha1.IngressSpec{
 				DeprecatedVisibility: v1alpha1.IngressVisibilityExternalIP,
 				Rules: []v1alpha1.IngressRule{{
-					Hosts:      []string{"doo.bar.foo.net-contour.invalid"},
+					Hosts:      []string{"doo.gen-0.bar.foo.net-contour.invalid"},
 					Visibility: v1alpha1.IngressVisibilityExternalIP,
 					HTTP: &v1alpha1.HTTPIngressRuleValue{
 						Paths: []v1alpha1.HTTPIngressPath{{
@@ -495,7 +497,7 @@ func TestMakeEndpointProbeIngress(t *testing.T) {
 						}},
 					},
 				}, {
-					Hosts:      []string{"goo.bar.foo.net-contour.invalid"},
+					Hosts:      []string{"goo.gen-0.bar.foo.net-contour.invalid"},
 					Visibility: v1alpha1.IngressVisibilityExternalIP,
 					HTTP: &v1alpha1.HTTPIngressRuleValue{
 						Paths: []v1alpha1.HTTPIngressPath{{
@@ -647,7 +649,7 @@ func TestMakeEndpointProbeIngress(t *testing.T) {
 			Spec: v1alpha1.IngressSpec{
 				DeprecatedVisibility: v1alpha1.IngressVisibilityExternalIP,
 				Rules: []v1alpha1.IngressRule{{
-					Hosts:      []string{"doo.bar.foo.net-contour.invalid"},
+					Hosts:      []string{"doo.gen-0.bar.foo.net-contour.invalid"},
 					Visibility: v1alpha1.IngressVisibilityExternalIP,
 					HTTP: &v1alpha1.HTTPIngressRuleValue{
 						Paths: []v1alpha1.HTTPIngressPath{{
@@ -662,7 +664,7 @@ func TestMakeEndpointProbeIngress(t *testing.T) {
 						}},
 					},
 				}, {
-					Hosts:      []string{"fu.bar.foo.net-contour.invalid"},
+					Hosts:      []string{"fu.gen-0.bar.foo.net-contour.invalid"},
 					Visibility: v1alpha1.IngressVisibilityExternalIP,
 					HTTP: &v1alpha1.HTTPIngressRuleValue{
 						Paths: []v1alpha1.HTTPIngressPath{{
@@ -677,7 +679,7 @@ func TestMakeEndpointProbeIngress(t *testing.T) {
 						}},
 					},
 				}, {
-					Hosts:      []string{"goo.bar.foo.net-contour.invalid"},
+					Hosts:      []string{"goo.gen-0.bar.foo.net-contour.invalid"},
 					Visibility: v1alpha1.IngressVisibilityExternalIP,
 					HTTP: &v1alpha1.HTTPIngressRuleValue{
 						Paths: []v1alpha1.HTTPIngressPath{{
@@ -692,7 +694,7 @@ func TestMakeEndpointProbeIngress(t *testing.T) {
 						}},
 					},
 				}, {
-					Hosts:      []string{"kung.bar.foo.net-contour.invalid"},
+					Hosts:      []string{"kung.gen-0.bar.foo.net-contour.invalid"},
 					Visibility: v1alpha1.IngressVisibilityExternalIP,
 					HTTP: &v1alpha1.HTTPIngressRuleValue{
 						Paths: []v1alpha1.HTTPIngressPath{{
@@ -754,7 +756,7 @@ func TestMakeEndpointProbeIngress(t *testing.T) {
 			Spec: v1alpha1.IngressSpec{
 				DeprecatedVisibility: v1alpha1.IngressVisibilityExternalIP,
 				Rules: []v1alpha1.IngressRule{{
-					Hosts:      []string{"goo.bar.foo.net-contour.invalid"},
+					Hosts:      []string{"goo.gen-0.bar.foo.net-contour.invalid"},
 					Visibility: v1alpha1.IngressVisibilityExternalIP,
 					HTTP: &v1alpha1.HTTPIngressRuleValue{
 						Paths: []v1alpha1.HTTPIngressPath{{


### PR DESCRIPTION
While investigating https://github.com/knative-sandbox/net-contour/issues/214 I noticed that the prober was seeing mismatched hashes when probing the hostnames of the endpoint probe kingress.  I might expect this if the kingress probe were updated, but I believe it was created fresh, so collisions are bizarre.  One plausible explanation of the 503s in the linked issue would be:

1. Main `kingress` reached steady state, endpoint probe `kingress` is deleted.
2. Main `kingress` is reprogrammed.
3. Fresh endpoint probe `kingress` is created with the relevant services.
4. HTTP Proxy from prior endpoint probe is leftover with the exitting service name, and the new endpoint probe updates it instead of creating a new HTTP Proxy.
5. Endpoint probe `kingress` successfully probes the updated HTTP Proxy that it does not own, and reports success.
6. Kubernetes GC catches up and deletes the HTTP Proxy owned by the prior endpoint probe.
7. Thinking the endpoints are adequately covered by the endpoint probe, the main kingress updates the main HTTP Proxy resources.
8. All references to the exitting service have been dropped from HTTP Proxy resources, so the cluster is removed from Envoy.
9. However, the "Cluster" corresponding to that service was still referenced by a "Route", so traffic hitting that "Route" returns a 503.

Reusing HTTP Proxy resources across generations of the kingress probe was never a requirement or goal, so this change simply avoids the possibility of collisions by incorporating the generation of the main `kingress` being probed into the hostnames using when constructing the endpoint probe.

Related: https://github.com/knative-sandbox/net-contour/issues/214