### PR TITLE
Resume building Contour from source

### DIFF
--- a/config/contour/external.yaml
+++ b/config/contour/external.yaml
@@ -1499,7 +1499,7 @@ spec:
         # if we change this on each version, you can no longer upgrade
         # just by applying the deployment YAML.
         # See #2423, #2395, #2150, and #2030 for earlier questions about this.
-        image: docker.io/projectcontour/contour:latest
+        image: ko://github.com/projectcontour/contour/cmd/contour
         imagePullPolicy: Always
         command:
         - contour
@@ -1704,7 +1704,7 @@ spec:
         - --contour-key-file=/certs/tls.key
         - --config-path=/config/contour.yaml
         command: ["contour"]
-        image: docker.io/projectcontour/contour:v1.8.1
+        image: ko://github.com/projectcontour/contour/cmd/contour
         imagePullPolicy: IfNotPresent
         name: contour
         ports:
@@ -1790,7 +1790,7 @@ spec:
         args:
         - envoy
         - shutdown-manager
-        image: docker.io/projectcontour/contour:v1.8.1
+        image: ko://github.com/projectcontour/contour/cmd/contour
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
@@ -1866,7 +1866,7 @@ spec:
         - --envoy-key-file=/certs/tls.key
         command:
         - contour
-        image: docker.io/projectcontour/contour:v1.8.1
+        image: ko://github.com/projectcontour/contour/cmd/contour
         imagePullPolicy: IfNotPresent
         name: envoy-initconfig
         volumeMounts:

--- a/config/contour/internal.yaml
+++ b/config/contour/internal.yaml
@@ -1499,7 +1499,7 @@ spec:
         # if we change this on each version, you can no longer upgrade
         # just by applying the deployment YAML.
         # See #2423, #2395, #2150, and #2030 for earlier questions about this.
-        image: docker.io/projectcontour/contour:latest
+        image: ko://github.com/projectcontour/contour/cmd/contour
         imagePullPolicy: Always
         command:
         - contour
@@ -1704,7 +1704,7 @@ spec:
         - --contour-key-file=/certs/tls.key
         - --config-path=/config/contour.yaml
         command: ["contour"]
-        image: docker.io/projectcontour/contour:v1.8.1
+        image: ko://github.com/projectcontour/contour/cmd/contour
         imagePullPolicy: IfNotPresent
         name: contour
         ports:
@@ -1790,7 +1790,7 @@ spec:
         args:
         - envoy
         - shutdown-manager
-        image: docker.io/projectcontour/contour:v1.8.1
+        image: ko://github.com/projectcontour/contour/cmd/contour
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
@@ -1866,7 +1866,7 @@ spec:
         - --envoy-key-file=/certs/tls.key
         command:
         - contour
-        image: docker.io/projectcontour/contour:v1.8.1
+        image: ko://github.com/projectcontour/contour/cmd/contour
         imagePullPolicy: IfNotPresent
         name: envoy-initconfig
         volumeMounts:

--- a/hack/update-deps.sh
+++ b/hack/update-deps.sh
@@ -86,8 +86,7 @@ function rewrite_serve_args() {
 }
 
 function rewrite_image() {
-  # sed -E $'s@docker.io/projectcontour/contour:.+@ko://github.com/projectcontour/contour/cmd/contour@g'
-  cat
+  sed -E $'s@docker.io/projectcontour/contour:.+@ko://github.com/projectcontour/contour/cmd/contour@g'
 }
 
 function rewrite_command() {


### PR DESCRIPTION
The motivation for this is that it makes it significantly easier to iterate on changes when you can just modify Contour directly in `vendor/` and have those changes reflected.  This might also enable us to better test Contour integration via an upstream pre-submit check via https://github.com/knative-sandbox/downstream-test-go.