### PR TITLE
Skip probe previous endpoints when HTTPProxy is not valid

### DIFF
--- a/pkg/reconciler/contour/contour.go
+++ b/pkg/reconciler/contour/contour.go
@@ -223,7 +223,7 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, ing *v1alpha1.Ingress) r
 			return err
 		}
 		if diff, err := kmp.SafeDiff(update, matches[0]); err == nil {
-			logger.Debugf("Updated http proxy diff: %s", diff)
+			logger.Debug("Updated http proxy diff: ", diff)
 		} else {
 			logger.Warnw("Error diffing http proxy", zap.Error(err))
 		}

--- a/pkg/reconciler/contour/contour.go
+++ b/pkg/reconciler/contour/contour.go
@@ -223,10 +223,11 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, ing *v1alpha1.Ingress) r
 			return err
 		}
 		if diff, err := kmp.SafeDiff(update, matches[0]); err == nil {
-			logger.Debugf("Updated http proxy: %s", diff)
+			logger.Debugf("Updated http proxy diff: %s", diff)
 		} else {
 			logger.Warnw("Error diffing http proxy", zap.Error(err))
 		}
+		logger.Debugf("Updated http proxy: %#v", update)
 	}
 
 	// Before deleting old programming, check our cache to see whether there is anything to clean up.

--- a/pkg/reconciler/contour/resources/kingress.go
+++ b/pkg/reconciler/contour/resources/kingress.go
@@ -51,11 +51,10 @@ func MakeEndpointProbeIngress(ctx context.Context, ing *v1alpha1.Ingress, previo
 
 	// Reverse engineer our previous state from the prior generation's HTTP Proxy resources.
 	for _, proxy := range previousState {
-		logging.FromContext(ctx).Infof("previous state from proxy %q status = %q", proxy.Name, proxy.Status.CurrentStatus)
-
 		// Skip probe when status is not valid. It happens when the previous revision was garbage collected.
 		// see: https://github.com/knative/serving/issues/9582
 		if proxy.Status.CurrentStatus != "valid" {
+			logging.FromContext(ctx).Infof("Skip invalid proxy: %#v", proxy)
 			continue
 		}
 

--- a/pkg/reconciler/contour/resources/kingress.go
+++ b/pkg/reconciler/contour/resources/kingress.go
@@ -51,6 +51,8 @@ func MakeEndpointProbeIngress(ctx context.Context, ing *v1alpha1.Ingress, previo
 
 	// Reverse engineer our previous state from the prior generation's HTTP Proxy resources.
 	for _, proxy := range previousState {
+		logging.FromContext(ctx).Infof("previous state from proxy %q status = %q", proxy.Name, proxy.Status.CurrentStatus)
+
 		// Skip probe when status is not valid. It happens when the previous revision was garbage collected.
 		// see: https://github.com/knative/serving/issues/9582
 		if proxy.Status.CurrentStatus != "valid" {

--- a/pkg/reconciler/contour/resources/kingress.go
+++ b/pkg/reconciler/contour/resources/kingress.go
@@ -51,6 +51,12 @@ func MakeEndpointProbeIngress(ctx context.Context, ing *v1alpha1.Ingress, previo
 
 	// Reverse engineer our previous state from the prior generation's HTTP Proxy resources.
 	for _, proxy := range previousState {
+		// Skip probe when status is not valid. It happens when the previous revision was garbage collected.
+		// see: https://github.com/knative/serving/issues/9582
+		if proxy.Status.CurrentStatus != "valid" {
+			continue
+		}
+
 		// Establish the visibility based on the class annotation.
 		var vis v1alpha1.IngressVisibility
 		for v, class := range config.FromContext(ctx).Contour.VisibilityClasses {

--- a/pkg/reconciler/contour/resources/kingress_test.go
+++ b/pkg/reconciler/contour/resources/kingress_test.go
@@ -463,6 +463,9 @@ func TestMakeEndpointProbeIngress(t *testing.T) {
 					}},
 				}},
 			},
+			Status: v1.HTTPProxyStatus{
+				CurrentStatus: "valid",
+			},
 		}},
 		want: &v1alpha1.Ingress{
 			ObjectMeta: metav1.ObjectMeta{
@@ -629,6 +632,9 @@ func TestMakeEndpointProbeIngress(t *testing.T) {
 						Port: 123,
 					}},
 				}},
+			},
+			Status: v1.HTTPProxyStatus{
+				CurrentStatus: "valid",
 			},
 		}},
 		want: &v1alpha1.Ingress{


### PR DESCRIPTION
If Revision was cleaned up by GC before probing the endpoint, Ksvc
never becomes Ready and prober keeps trying to probe forever.

Please see https://github.com/knative-sandbox/net-contour/issues/275 for the detail.

This patch fixes it by skipping probe if HTTPProxy is not valid.

Fixes https://github.com/knative-sandbox/net-contour/issues/275 https://github.com/knative/serving/issues/9582

/cc @mattmoor @whaught