### PR TITLE
Start testing with multi-arch

### DIFF
--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -114,7 +114,7 @@ jobs:
         # Build and Publish our containers to the docker daemon (including test assets)
         export GO111MODULE=on
         export GOFLAGS=-mod=vendor
-        ko resolve -Pf test/config/ -f config/contour -f config | \
+        ko resolve --platform=all -Pf test/config/ -f config/contour -f config | \
           sed 's/LoadBalancer/NodePort/g' | \
           sed 's/imagePullPolicy:/# DISABLED: imagePullPolicy:/g' | \
           kubectl apply -f -


### PR DESCRIPTION
Once https://github.com/GoogleContainerTools/distroless/pull/591 lands, this will have us start building and producing multi-arch images.  Only the amd64 flavor will be tested, but this will start to get some mileage through the manifest list path.