### PR TITLE
Publish multi-arch during CI

### DIFF
--- a/hack/release.sh
+++ b/hack/release.sh
@@ -48,7 +48,7 @@ function build_release() {
   for yaml in "${!COMPONENTS[@]}"; do
     local config="${COMPONENTS[${yaml}]}"
     echo "Building Knative net-contour - ${config}"
-    ko resolve --strict ${KO_FLAGS} -f ${config}/ | "${LABEL_YAML_CMD[@]}" > ${yaml}
+    ko resolve --platform=all --strict ${KO_FLAGS} -f ${config}/ | "${LABEL_YAML_CMD[@]}" > ${yaml}
     all_yamls+=(${yaml})
   done
   # Assemble the release

--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -34,12 +34,12 @@ function test_setup() {
   echo ">> Publishing test images"
   $(dirname $0)/upload-test-images.sh || fail_test "Error uploading test images"
   echo ">> Creating test resources (test/config/)"
-  ko apply ${KO_FLAGS} -f test/config/ || return 1
+  ko apply --platform=all ${KO_FLAGS} -f test/config/ || return 1
 
   # Bringing up controllers.
   echo ">> Bringing up Contour"
   # Switch Envoy to emit debug-level logging.
-  ko resolve -f config/contour | \
+  ko resolve --platform=all -f config/contour | \
     sed 's/--log-level info/--log-level debug/g' | \
     kubectl apply -f - || return 1
   wait_until_batch_job_complete contour-external || return 1
@@ -47,7 +47,7 @@ function test_setup() {
   wait_until_service_has_external_ip contour-external envoy
 
   echo ">> Bringing up net-contour"
-  ko apply -f config/ || return 1
+  ko apply --platform=all -f config/ || return 1
 
   scale_controlplane contour-ingress-controller
 

--- a/test/upload-test-images.sh
+++ b/test/upload-test-images.sh
@@ -33,7 +33,7 @@ function upload_test_images() {
       sed "s@ko://@ko://knative.dev/net-contour/vendor/@g" $yaml \
         `# ko resolve is being used for the side-effect of publishing images,` \
         `# so the resulting yaml produced is ignored.` \
-        | ko resolve --strict ${tag_option} -RBf- > /dev/null
+        | ko resolve --platform=all --strict ${tag_option} -RBf- > /dev/null
     done
   )
 }


### PR DESCRIPTION
This still won't work anywhere but amd64 because Envoy is an amd64 image, but 1.16 should start shipping multi-arch images.