### PR TITLE
Use default leader election config

### DIFF
--- a/config/contour/external.yaml
+++ b/config/contour/external.yaml
@@ -60,9 +60,6 @@ metadata:
     networking.knative.dev/ingress-provider: contour
 data:
   contour.yaml: |
-    leaderelection:
-      configmap-name: contour
-      configmap-namespace: contour-external
     # should contour expect to be running inside a k8s cluster
     # incluster: true
     #

--- a/config/contour/internal.yaml
+++ b/config/contour/internal.yaml
@@ -60,9 +60,6 @@ metadata:
     networking.knative.dev/ingress-provider: contour
 data:
   contour.yaml: |
-    leaderelection:
-      configmap-name: contour
-      configmap-namespace: contour-internal
     # should contour expect to be running inside a k8s cluster
     # incluster: true
     #

--- a/hack/update-deps.sh
+++ b/hack/update-deps.sh
@@ -77,10 +77,6 @@ function rewrite_contour_namespace() {
       | sed "s@name: projectcontour@name: $1@g"
 }
 
-function configure_leader_election() {
-  sed -e $'s@  contour.yaml: |@  contour.yaml: |\\\n    leaderelection:\\\n      configmap-name: contour\\\n      configmap-namespace: '$1'@g'
-}
-
 function rewrite_serve_args() {
   sed -e $'s@        - serve@        - serve\\\n        - --ingress-class-name='$1'@g'
 }
@@ -136,7 +132,6 @@ EOF
 contour_yaml \
   | delete_contour_cluster_role_bindings \
   | rewrite_contour_namespace contour-internal \
-  | configure_leader_election contour-internal \
   | rewrite_serve_args contour-internal | rewrite_user \
   | rewrite_image | rewrite_command | disable_hostport | privatize_loadbalancer \
   | add_ingress_provider_labels  >> config/contour/internal.yaml
@@ -164,7 +159,6 @@ EOF
 contour_yaml \
   | delete_contour_cluster_role_bindings \
   | rewrite_contour_namespace contour-external \
-  | configure_leader_election contour-external \
   | rewrite_serve_args contour-external | rewrite_user \
   | rewrite_image | rewrite_command | disable_hostport \
   | add_ingress_provider_labels >> config/contour/external.yaml


### PR DESCRIPTION
Restore default leader election config to avoid contention on the
`contour` ConfigMap. Contour will create a `leader-elect` ConfigMap for
each namespace that is dedicated to the leader election.

This change should allow tools like kapp to update the contour config
with an optimistic lock based on the current resource version.
Previously, the resource would mutate before kapp could complete the
update.

Signed-off-by: Scott Andrews <andrewssc@vmware.com>