### PR TITLE
Remove ingress timeout

### DIFF
--- a/pkg/reconciler/contour/contour_test.go
+++ b/pkg/reconciler/contour/contour_test.go
@@ -726,7 +726,6 @@ func withBasicSpec(i *v1alpha1.Ingress) {
 			Visibility: v1alpha1.IngressVisibilityExternalIP,
 			HTTP: &v1alpha1.HTTPIngressRuleValue{
 				Paths: []v1alpha1.HTTPIngressPath{{
-					Timeout: &metav1.Duration{Duration: time.Second},
 					Splits: []v1alpha1.IngressBackendSplit{{
 						IngressBackend: v1alpha1.IngressBackend{
 							ServiceName:      "goo",
@@ -748,7 +747,6 @@ func withBasicSpec2(i *v1alpha1.Ingress) {
 			Visibility: v1alpha1.IngressVisibilityExternalIP,
 			HTTP: &v1alpha1.HTTPIngressRuleValue{
 				Paths: []v1alpha1.HTTPIngressPath{{
-					Timeout: &metav1.Duration{Duration: time.Second},
 					Splits: []v1alpha1.IngressBackendSplit{{
 						IngressBackend: v1alpha1.IngressBackend{
 							ServiceName:      "doo",
@@ -770,7 +768,6 @@ func withMultiProxySpec(i *v1alpha1.Ingress) {
 			Visibility: v1alpha1.IngressVisibilityExternalIP,
 			HTTP: &v1alpha1.HTTPIngressRuleValue{
 				Paths: []v1alpha1.HTTPIngressPath{{
-					Timeout: &metav1.Duration{Duration: time.Second},
 					Splits: []v1alpha1.IngressBackendSplit{{
 						IngressBackend: v1alpha1.IngressBackend{
 							ServiceName:      "goo",

--- a/pkg/reconciler/contour/resources/httpproxy.go
+++ b/pkg/reconciler/contour/resources/httpproxy.go
@@ -124,15 +124,8 @@ func MakeHTTPProxies(ctx context.Context, ing *v1alpha1.Ingress, serviceToProtoc
 
 		routes := make([]v1.Route, 0, len(rule.HTTP.Paths))
 		for _, path := range rule.HTTP.Paths {
-			var top *v1.TimeoutPolicy
-			if path.Timeout != nil {
-				top = &v1.TimeoutPolicy{
-					Response: path.Timeout.Duration.String(),
-				}
-			} else {
-				top = &v1.TimeoutPolicy{
-					Response: "infinity",
-				}
+			top := &v1.TimeoutPolicy{
+				Response: "infinity",
 			}
 
 			// By default retry on connection problems twice.

--- a/pkg/reconciler/contour/resources/httpproxy_test.go
+++ b/pkg/reconciler/contour/resources/httpproxy_test.go
@@ -440,7 +440,7 @@ func TestMakeProxies(t *testing.T) {
 			},
 		}},
 	}, {
-		name: "cluster local visibility with retry policy and timeout",
+		name: "cluster local visibility with retry policy",
 		ing: &v1alpha1.Ingress{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: "foo",
@@ -456,7 +456,6 @@ func TestMakeProxies(t *testing.T) {
 								Attempts:      34,
 								PerTryTimeout: &metav1.Duration{Duration: 14 * time.Minute},
 							},
-							Timeout: &metav1.Duration{Duration: 46 * time.Minute},
 							Splits: []v1alpha1.IngressBackendSplit{{
 								IngressBackend: v1alpha1.IngressBackend{
 									ServiceName: "goo",
@@ -514,7 +513,7 @@ func TestMakeProxies(t *testing.T) {
 						},
 					},
 					TimeoutPolicy: &v1.TimeoutPolicy{
-						Response: "46m0s",
+						Response: "infinity",
 					},
 					Conditions: []v1.MatchCondition{{
 						Header: &v1.HeaderMatchCondition{
@@ -525,7 +524,7 @@ func TestMakeProxies(t *testing.T) {
 					RequestHeadersPolicy: &v1.HeadersPolicy{
 						Set: []v1.HeaderValue{{
 							Name:  "K-Network-Hash",
-							Value: "b53cd0662ebbe11c2eebbcab7728ae3992b7e9b7167bed423b2aa10646dc3e8e",
+							Value: "9e1b02792803e1cbd5153bea0600879842245f6d263bee0821f4b4be5a55e40f",
 						}},
 					},
 					Services: []v1.Service{{
@@ -554,7 +553,7 @@ func TestMakeProxies(t *testing.T) {
 						},
 					},
 					TimeoutPolicy: &v1.TimeoutPolicy{
-						Response: "46m0s",
+						Response: "infinity",
 					},
 					RequestHeadersPolicy: &v1.HeadersPolicy{
 						Set: []v1.HeaderValue{},

--- a/pkg/reconciler/contour/resources/kingress_test.go
+++ b/pkg/reconciler/contour/resources/kingress_test.go
@@ -228,7 +228,6 @@ func TestMakeEndpointProbeIngress(t *testing.T) {
 								Attempts:      34,
 								PerTryTimeout: &metav1.Duration{Duration: 14 * time.Minute},
 							},
-							Timeout: &metav1.Duration{Duration: 46 * time.Minute},
 							Splits: []v1alpha1.IngressBackendSplit{{
 								IngressBackend: v1alpha1.IngressBackend{
 									ServiceName: "goo",


### PR DESCRIPTION
Ingress's timeout was set to super long timeout by
https://github.com/knative/serving/pull/8965.

But the current conformance test for [omitted timeout ](https://github.com/knative/networking/pull/157) proved that we can drop
the timeout so knative/serving and knative/networking are dropping it.
Please see https://github.com/knative/networking/pull/228 and https://github.com/knative/serving/pull/9852.

Hence this patch removes timeout in net-contour to follow up them.

/cc @mattmoor @tcnghia 