### PR TITLE
Drop --platform=all from upload-test-images.sh

### DIFF
--- a/test/upload-test-images.sh
+++ b/test/upload-test-images.sh
@@ -33,7 +33,7 @@ function upload_test_images() {
       sed "s@ko://@ko://knative.dev/net-contour/vendor/@g" $yaml \
         `# ko resolve is being used for the side-effect of publishing images,` \
         `# so the resulting yaml produced is ignored.` \
-        | ko resolve --platform=all ${tag_option} -RBf- > /dev/null
+        | ko resolve ${tag_option} -RBf- > /dev/null
     done
   )
 }


### PR DESCRIPTION
This runs on every build, so it's unneeded latency, and I think we've gotten the mileage through multi-arch that I wanted.

Especially since distroless now has 4 architectures 🤩 