### PR TITLE
Make timeoutpolicy configurable in configmap

### DIFF
--- a/config/config-contour.yaml
+++ b/config/config-contour.yaml
@@ -28,6 +28,12 @@ data:
     #                              #
     ################################
 
+    # timeout-policy-idle sets TimeoutPolicy.Idle in contour HTTPProxy spec
+    timeout-policy-idle: "infinity"
+
+    # timeout-policy-response sets TimeoutPolicy.Response in contour HTTPProxy spec
+    timeou-policy-response: "infinity"
+
     # If auto-TLS is disabled fallback to the following certificate
     #
     # An operator is required to setup a TLSCertificateDelegation

--- a/pkg/reconciler/contour/config/contour_test.go
+++ b/pkg/reconciler/contour/config/contour_test.go
@@ -81,6 +81,120 @@ func TestDefaultTLSSecret(t *testing.T) {
 	}
 }
 
+func TestTimeoutPolicyResponse(t *testing.T) {
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: system.Namespace(),
+			Name:      ContourConfigName,
+		},
+		Data: map[string]string{
+			"timeout-policy-response": "60s",
+		},
+	}
+
+	cfg, err := NewContourFromConfigMap(cm)
+	if err != nil {
+		t.Error("NewContourFromConfigMap(timeout-policy-response:60s) =", err)
+	}
+
+	if got, want := cfg.TimeoutPolicyResponse, "60s"; got != want {
+		t.Errorf("TimeoutPolicyResponse got %q want %q", got, want)
+	}
+
+	cm.Data["timeout-policy-response"] = "infinity"
+	cfg, err = NewContourFromConfigMap(cm)
+	if err != nil {
+		t.Error("NewContourFromConfigMap(timeout-policy-response:infinity) =", err)
+	}
+
+	if got, want := cfg.TimeoutPolicyResponse, "infinity"; got != want {
+		t.Errorf("TimeoutPolicyResponse got %q want %q", got, want)
+	}
+
+	delete(cm.Data, "timeout-policy-response")
+	cfg, err = NewContourFromConfigMap(cm)
+	if err != nil {
+		t.Error("NewContourFromConfigMap(timeout-policy-response:60s) =", err)
+	}
+
+	if cfg.TimeoutPolicyResponse != "infinity" {
+		t.Errorf("TimeoutPolicyResponse got %q - want empty", cfg.TimeoutPolicyResponse)
+	}
+
+	// format should be as per time.ParseDuration
+	cm.Data["timeout-policy-response"] = "60"
+
+	_, err = NewContourFromConfigMap(cm)
+	if err == nil {
+		t.Errorf("expected an error parsing erroneous 'timeout-policy-response'")
+	}
+
+	// This should be "infinity"
+	cm.Data["timeout-policy-response"] = "xyz"
+
+	_, err = NewContourFromConfigMap(cm)
+	if err == nil {
+		t.Errorf("expected an error parsing erroneous 'timeout-policy-response'")
+	}
+}
+
+func TestTimeoutPolicyIdle(t *testing.T) {
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: system.Namespace(),
+			Name:      ContourConfigName,
+		},
+		Data: map[string]string{
+			"timeout-policy-idle": "60s",
+		},
+	}
+
+	cfg, err := NewContourFromConfigMap(cm)
+	if err != nil {
+		t.Error("NewContourFromConfigMap(timeout-policy-idle:60s) =", err)
+	}
+
+	if got, want := cfg.TimeoutPolicyIdle, "60s"; got != want {
+		t.Errorf("TimeoutPolicyIdle got %q want %q", got, want)
+	}
+
+	cm.Data["timeout-policy-idle"] = "infinity"
+	cfg, err = NewContourFromConfigMap(cm)
+	if err != nil {
+		t.Error("NewContourFromConfigMap(timeout-policy-idle:infinity) =", err)
+	}
+
+	if got, want := cfg.TimeoutPolicyIdle, "infinity"; got != want {
+		t.Errorf("TimeoutPolicyIdle got %q want %q", got, want)
+	}
+	delete(cm.Data, "timeoutPolicy-idle")
+
+	cfg, err = NewContourFromConfigMap(cm)
+	if err != nil {
+		t.Error("NewContourFromConfigMap(timeout-policy-idle:60s) =", err)
+	}
+
+	if cfg.TimeoutPolicyIdle != "infinity" {
+		t.Errorf("TimeoutPolicyIdle got %q - want empty", cfg.TimeoutPolicyIdle)
+	}
+
+	// format should be as per time.ParseDuration
+	cm.Data["timeout-policy-idle"] = "60"
+
+	_, err = NewContourFromConfigMap(cm)
+	if err == nil {
+		t.Errorf("expected an error parsing erroneous 'timeout-policy-idle'")
+	}
+
+	// This should be "infinity"
+	cm.Data["timeout-policy-idle"] = "xyz"
+
+	_, err = NewContourFromConfigMap(cm)
+	if err == nil {
+		t.Errorf("expected an error parsing erroneous 'timeout-policy-idle'")
+	}
+}
+
 func TestConfigurationErrors(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/pkg/reconciler/contour/resources/httpproxy.go
+++ b/pkg/reconciler/contour/resources/httpproxy.go
@@ -125,7 +125,8 @@ func MakeHTTPProxies(ctx context.Context, ing *v1alpha1.Ingress, serviceToProtoc
 		routes := make([]v1.Route, 0, len(rule.HTTP.Paths))
 		for _, path := range rule.HTTP.Paths {
 			top := &v1.TimeoutPolicy{
-				Response: "infinity",
+				Response: config.FromContext(ctx).Contour.TimeoutPolicyResponse,
+				Idle:     config.FromContext(ctx).Contour.TimeoutPolicyIdle,
 			}
 
 			// By default retry on connection problems twice.

--- a/pkg/reconciler/contour/resources/httpproxy_test.go
+++ b/pkg/reconciler/contour/resources/httpproxy_test.go
@@ -124,6 +124,7 @@ func TestMakeProxies(t *testing.T) {
 					PermitInsecure:   true,
 					TimeoutPolicy: &v1.TimeoutPolicy{
 						Response: "infinity",
+						Idle:     "infinity",
 					},
 					RetryPolicy: defaultRetryPolicy(),
 					Conditions: []v1.MatchCondition{{
@@ -171,6 +172,7 @@ func TestMakeProxies(t *testing.T) {
 					PermitInsecure:   true,
 					TimeoutPolicy: &v1.TimeoutPolicy{
 						Response: "infinity",
+						Idle:     "infinity",
 					},
 					RetryPolicy: defaultRetryPolicy(),
 					RequestHeadersPolicy: &v1.HeadersPolicy{
@@ -264,6 +266,7 @@ func TestMakeProxies(t *testing.T) {
 					PermitInsecure:   true,
 					TimeoutPolicy: &v1.TimeoutPolicy{
 						Response: "infinity",
+						Idle:     "infinity",
 					},
 					RetryPolicy: defaultRetryPolicy(),
 					Conditions: []v1.MatchCondition{{
@@ -289,6 +292,7 @@ func TestMakeProxies(t *testing.T) {
 					PermitInsecure:   true,
 					TimeoutPolicy: &v1.TimeoutPolicy{
 						Response: "infinity",
+						Idle:     "infinity",
 					},
 					RetryPolicy: defaultRetryPolicy(),
 					RequestHeadersPolicy: &v1.HeadersPolicy{
@@ -332,6 +336,7 @@ func TestMakeProxies(t *testing.T) {
 					PermitInsecure:   true,
 					TimeoutPolicy: &v1.TimeoutPolicy{
 						Response: "infinity",
+						Idle:     "infinity",
 					},
 					RetryPolicy: defaultRetryPolicy(),
 					Conditions: []v1.MatchCondition{{
@@ -357,6 +362,7 @@ func TestMakeProxies(t *testing.T) {
 					PermitInsecure:   true,
 					TimeoutPolicy: &v1.TimeoutPolicy{
 						Response: "infinity",
+						Idle:     "infinity",
 					},
 					RetryPolicy: defaultRetryPolicy(),
 					RequestHeadersPolicy: &v1.HeadersPolicy{
@@ -400,6 +406,7 @@ func TestMakeProxies(t *testing.T) {
 					PermitInsecure:   true,
 					TimeoutPolicy: &v1.TimeoutPolicy{
 						Response: "infinity",
+						Idle:     "infinity",
 					},
 					RetryPolicy: defaultRetryPolicy(),
 					Conditions: []v1.MatchCondition{{
@@ -425,6 +432,7 @@ func TestMakeProxies(t *testing.T) {
 					PermitInsecure:   true,
 					TimeoutPolicy: &v1.TimeoutPolicy{
 						Response: "infinity",
+						Idle:     "infinity",
 					},
 					RetryPolicy: defaultRetryPolicy(),
 					RequestHeadersPolicy: &v1.HeadersPolicy{
@@ -514,6 +522,7 @@ func TestMakeProxies(t *testing.T) {
 					},
 					TimeoutPolicy: &v1.TimeoutPolicy{
 						Response: "infinity",
+						Idle:     "infinity",
 					},
 					Conditions: []v1.MatchCondition{{
 						Header: &v1.HeaderMatchCondition{
@@ -554,6 +563,7 @@ func TestMakeProxies(t *testing.T) {
 					},
 					TimeoutPolicy: &v1.TimeoutPolicy{
 						Response: "infinity",
+						Idle:     "infinity",
 					},
 					RequestHeadersPolicy: &v1.HeadersPolicy{
 						Set: []v1.HeaderValue{},
@@ -655,6 +665,7 @@ func TestMakeProxies(t *testing.T) {
 					PermitInsecure:   true,
 					TimeoutPolicy: &v1.TimeoutPolicy{
 						Response: "infinity",
+						Idle:     "infinity",
 					},
 					RetryPolicy: defaultRetryPolicy(),
 					RequestHeadersPolicy: &v1.HeadersPolicy{
@@ -687,6 +698,7 @@ func TestMakeProxies(t *testing.T) {
 					PermitInsecure:   true,
 					TimeoutPolicy: &v1.TimeoutPolicy{
 						Response: "infinity",
+						Idle:     "infinity",
 					},
 					RetryPolicy: defaultRetryPolicy(),
 					RequestHeadersPolicy: &v1.HeadersPolicy{
@@ -713,6 +725,7 @@ func TestMakeProxies(t *testing.T) {
 					PermitInsecure:   true,
 					TimeoutPolicy: &v1.TimeoutPolicy{
 						Response: "infinity",
+						Idle:     "infinity",
 					},
 					RetryPolicy: defaultRetryPolicy(),
 					RequestHeadersPolicy: &v1.HeadersPolicy{
@@ -737,6 +750,7 @@ func TestMakeProxies(t *testing.T) {
 					PermitInsecure:   true,
 					TimeoutPolicy: &v1.TimeoutPolicy{
 						Response: "infinity",
+						Idle:     "infinity",
 					},
 					RetryPolicy: defaultRetryPolicy(),
 					RequestHeadersPolicy: &v1.HeadersPolicy{
@@ -829,6 +843,7 @@ func TestMakeProxies(t *testing.T) {
 					PermitInsecure:   false,
 					TimeoutPolicy: &v1.TimeoutPolicy{
 						Response: "infinity",
+						Idle:     "infinity",
 					},
 					RetryPolicy: defaultRetryPolicy(),
 					Conditions: []v1.MatchCondition{{
@@ -873,6 +888,7 @@ func TestMakeProxies(t *testing.T) {
 					PermitInsecure:   false,
 					TimeoutPolicy: &v1.TimeoutPolicy{
 						Response: "infinity",
+						Idle:     "infinity",
 					},
 					RetryPolicy: defaultRetryPolicy(),
 					RequestHeadersPolicy: &v1.HeadersPolicy{
@@ -985,6 +1001,7 @@ func TestMakeProxies(t *testing.T) {
 					PermitInsecure:   true,
 					TimeoutPolicy: &v1.TimeoutPolicy{
 						Response: "infinity",
+						Idle:     "infinity",
 					},
 					RetryPolicy: defaultRetryPolicy(),
 					Conditions: []v1.MatchCondition{{
@@ -1029,6 +1046,7 @@ func TestMakeProxies(t *testing.T) {
 					PermitInsecure:   true,
 					TimeoutPolicy: &v1.TimeoutPolicy{
 						Response: "infinity",
+						Idle:     "infinity",
 					},
 					RetryPolicy: defaultRetryPolicy(),
 					RequestHeadersPolicy: &v1.HeadersPolicy{
@@ -1129,6 +1147,7 @@ func TestMakeProxies(t *testing.T) {
 					PermitInsecure:   true,
 					TimeoutPolicy: &v1.TimeoutPolicy{
 						Response: "infinity",
+						Idle:     "infinity",
 					},
 					RetryPolicy: defaultRetryPolicy(),
 					Conditions: []v1.MatchCondition{{
@@ -1160,6 +1179,122 @@ func TestMakeProxies(t *testing.T) {
 					PermitInsecure:   true,
 					TimeoutPolicy: &v1.TimeoutPolicy{
 						Response: "infinity",
+						Idle:     "infinity",
+					},
+					RetryPolicy: defaultRetryPolicy(),
+					RequestHeadersPolicy: &v1.HeadersPolicy{
+						Set: []v1.HeaderValue{},
+					},
+					Services: []v1.Service{{
+						Name:     "goo",
+						Protocol: &protocol,
+						Port:     123,
+						Weight:   100,
+						RequestHeadersPolicy: &v1.HeadersPolicy{
+							Set: []v1.HeaderValue{{
+								Name:  "Baz",
+								Value: "blah",
+							}},
+						},
+					}},
+				}},
+			},
+		}},
+	}, {
+		name: "single external domain with TimeoutPolicyResponse and TimeoutPolicyIdle set",
+		modifyConfig: func(c *config.Config) {
+			c.Contour.TimeoutPolicyResponse = "60s"
+			c.Contour.TimeoutPolicyIdle = "60s"
+		},
+		ing: &v1alpha1.Ingress{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "foo",
+				Name:      "bar",
+			},
+			Spec: v1alpha1.IngressSpec{
+				Rules: []v1alpha1.IngressRule{{
+					Hosts:      []string{"example.com"},
+					Visibility: v1alpha1.IngressVisibilityExternalIP,
+					HTTP: &v1alpha1.HTTPIngressRuleValue{
+						Paths: []v1alpha1.HTTPIngressPath{{
+							Splits: []v1alpha1.IngressBackendSplit{{
+								IngressBackend: v1alpha1.IngressBackend{
+									ServiceName: "goo",
+									ServicePort: intstr.FromInt(123),
+								},
+								Percent: 100,
+								AppendHeaders: map[string]string{
+									"Baz": "blah",
+								},
+							}},
+						}},
+					},
+				}},
+			},
+		},
+		want: []*v1.HTTPProxy{{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "foo",
+				Name:      "bar-" + publicClass + "-example.com",
+				Labels: map[string]string{
+					DomainHashKey: "0caaf24ab1a0c33440c06afe99df986365b0781f",
+					GenerationKey: "0",
+					ParentKey:     "bar",
+					ClassKey:      publicClass,
+				},
+				Annotations: map[string]string{
+					ClassKey: publicClass,
+				},
+				OwnerReferences: []metav1.OwnerReference{{
+					APIVersion:         "networking.internal.knative.dev/v1alpha1",
+					Kind:               "Ingress",
+					Name:               "bar",
+					Controller:         ptr.Bool(true),
+					BlockOwnerDeletion: ptr.Bool(true),
+				}},
+			},
+			Spec: v1.HTTPProxySpec{
+				VirtualHost: &v1.VirtualHost{
+					Fqdn: "example.com",
+				},
+				Routes: []v1.Route{{
+					EnableWebsockets: true,
+					PermitInsecure:   true,
+					TimeoutPolicy: &v1.TimeoutPolicy{
+						Response: "60s",
+						Idle:     "60s",
+					},
+					RetryPolicy: defaultRetryPolicy(),
+					Conditions: []v1.MatchCondition{{
+						Header: &v1.HeaderMatchCondition{
+							Name:  "K-Network-Hash",
+							Exact: "override",
+						},
+					}},
+					RequestHeadersPolicy: &v1.HeadersPolicy{
+						Set: []v1.HeaderValue{{
+							Name:  "K-Network-Hash",
+							Value: "f87d6dc22c28a3558c40fc7c774c8656f79011ca70d21103d469c310ac5c0bc7",
+						}},
+					},
+					Services: []v1.Service{{
+						Name:     "goo",
+						Protocol: &protocol,
+						Port:     123,
+						Weight:   100,
+						RequestHeadersPolicy: &v1.HeadersPolicy{
+							Set: []v1.HeaderValue{{
+								Name:  "Baz",
+								Value: "blah",
+							}},
+						},
+					}},
+				}, {
+					EnableWebsockets: true,
+					PermitInsecure:   true,
+					TimeoutPolicy: &v1.TimeoutPolicy{
+						Response: "60s",
+						Idle:     "60s",
 					},
 					RetryPolicy: defaultRetryPolicy(),
 					RequestHeadersPolicy: &v1.HeadersPolicy{
@@ -1239,6 +1374,7 @@ func TestMakeProxies(t *testing.T) {
 					PermitInsecure:   true,
 					TimeoutPolicy: &v1.TimeoutPolicy{
 						Response: "infinity",
+						Idle:     "infinity",
 					},
 					RetryPolicy: defaultRetryPolicy(),
 					Conditions: []v1.MatchCondition{{
@@ -1273,6 +1409,7 @@ func TestMakeProxies(t *testing.T) {
 					PermitInsecure:   true,
 					TimeoutPolicy: &v1.TimeoutPolicy{
 						Response: "infinity",
+						Idle:     "infinity",
 					},
 					RetryPolicy: defaultRetryPolicy(),
 					RequestHeadersPolicy: &v1.HeadersPolicy{
@@ -1311,6 +1448,8 @@ func TestMakeProxies(t *testing.T) {
 						v1alpha1.IngressVisibilityClusterLocal: privateClass,
 						v1alpha1.IngressVisibilityExternalIP:   publicClass,
 					},
+					TimeoutPolicyResponse: "infinity",
+					TimeoutPolicyIdle:     "infinity",
 				},
 				Network: &networkingpkg.Config{
 					HTTPProtocol: sec,


### PR DESCRIPTION
Currently TimeoutPolicy is hardcoded to infinity. As an operator I should be able to configure it in the config map.

Fixes #326 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Setting TimeoutPolicy.Response and TimeoutPolicy.Idle to "infinity" by default. These are configurable from config-contour.yaml
```