### PR TITLE
Do not use p option for mktemp to support Mac OS in verify-codegen.sh

### DIFF
--- a/hack/verify-codegen.sh
+++ b/hack/verify-codegen.sh
@@ -19,7 +19,7 @@ set -o nounset
 set -o pipefail
 
 readonly REPO_ROOT_DIR="$(git rev-parse --show-toplevel)"
-readonly TMP_DIFFROOT="$(mktemp -d -p ${REPO_ROOT_DIR})"
+readonly TMP_DIFFROOT="$(TMPDIR=${REPO_ROOT_DIR} mktemp -d)"
 
 cleanup() {
   rm -rf "${TMP_DIFFROOT}"

--- a/hack/verify-codegen.sh
+++ b/hack/verify-codegen.sh
@@ -19,7 +19,7 @@ set -o nounset
 set -o pipefail
 
 readonly REPO_ROOT_DIR="$(git rev-parse --show-toplevel)"
-readonly TMP_DIFFROOT="$(TMPDIR=${REPO_ROOT_DIR} mktemp -d)"
+readonly TMP_DIFFROOT="$(mktemp -d)"
 
 cleanup() {
   rm -rf "${TMP_DIFFROOT}"


### PR DESCRIPTION
`mktemp` command does not support `-p` option on Mac OS - https://ss64.com/osx/mktemp.html.
Also `-p` option seems to be deprecated on Linux - https://www.gnu.org/software/autogen/mktemp.html.

Hence this patch change to use `mktemp -d` simply.

Some more context: https://knative.slack.com/archives/C012J5TCS6Q/p1603448481028700

/cc @mattmoor @dprotaso @arghya88 