### PR TITLE
Enable alpha and beta flag on KinD e2e

### DIFF
--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -154,6 +154,7 @@ jobs:
         # Run the tests tagged as e2e on the KinD cluster.
         go test -race -count=1 -short -timeout=20m -tags=e2e ${{ matrix.test-suite }} \
            --ingressendpoint="${IPS[0]}" \
+            --enable-beta --enable-alpha \
            --ingressClass=contour.ingress.networking.knative.dev \
            --cluster-suffix=$CLUSTER_SUFFIX
 


### PR DESCRIPTION
As per title, this patch enables alpha and beta flag on KinD e2e.

/cc @mattmoor @dprotaso 