### PR TITLE
Move to rbac v1

### DIFF
--- a/config/contour/external.yaml
+++ b/config/contour/external.yaml
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: contour-external
@@ -2016,7 +2016,7 @@ metadata:
   labels:
     networking.knative.dev/ingress-provider: contour
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: contour
@@ -2032,7 +2032,7 @@ subjects:
   name: contour-certgen
   namespace: contour-external
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: contour-certgen

--- a/config/contour/internal.yaml
+++ b/config/contour/internal.yaml
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: contour-internal
@@ -2016,7 +2016,7 @@ metadata:
   labels:
     networking.knative.dev/ingress-provider: contour
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: contour
@@ -2032,7 +2032,7 @@ subjects:
   name: contour-certgen
   namespace: contour-internal
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: contour-certgen

--- a/hack/update-deps.sh
+++ b/hack/update-deps.sh
@@ -83,7 +83,7 @@ rm -rf config/contour/*
 # We do this manually because it's challenging to rewrite
 # the ClusterRoleBinding without collateral damage.
 cat > config/contour/internal.yaml <<EOF
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: contour-internal
@@ -110,7 +110,7 @@ contour_yaml \
 # We do this manually because it's challenging to rewrite
 # the ClusterRoleBinding without collateral damage.
 cat > config/contour/external.yaml <<EOF
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: contour-external


### PR DESCRIPTION
Seeing a bunch of this when you deploy right now:

```
Warning: rbac.authorization.k8s.io/v1beta1 ClusterRoleBinding is deprecated in v1.17+, unavailable in v1.22+; use rbac.authorization.k8s.io/v1 ClusterRoleBinding
Warning: rbac.authorization.k8s.io/v1beta1 RoleBinding is deprecated in v1.17+, unavailable in v1.22+; use rbac.authorization.k8s.io/v1 RoleBinding
Warning: rbac.authorization.k8s.io/v1beta1 Role is deprecated in v1.17+, unavailable in v1.22+; use rbac.authorization.k8s.io/v1 Role
```