### PR TITLE
Add retry test image and remove default retry policy

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,6 @@ require (
 	k8s.io/apimachinery v0.19.7
 	k8s.io/client-go v0.19.7
 	knative.dev/hack v0.0.0-20210203173706-8368e1f6eacf
-	knative.dev/networking v0.0.0-20210204170711-b61da138ba21
+	knative.dev/networking v0.0.0-20210208003533-45b7ed13aeaa
 	knative.dev/pkg v0.0.0-20210204171111-887806985c09
 )

--- a/go.sum
+++ b/go.sum
@@ -1283,8 +1283,8 @@ knative.dev/hack v0.0.0-20210120165453-8d623a0af457 h1:jEBITgx/lQydGncM0uetpv/Zq
 knative.dev/hack v0.0.0-20210120165453-8d623a0af457/go.mod h1:PHt8x8yX5Z9pPquBEfIj0X66f8iWkWfR0S/sarACJrI=
 knative.dev/hack v0.0.0-20210203173706-8368e1f6eacf h1:u4cY4jr2LYvhoz/1HBWEPsMiLkm0HMdDTfmmw1RE8zE=
 knative.dev/hack v0.0.0-20210203173706-8368e1f6eacf/go.mod h1:PHt8x8yX5Z9pPquBEfIj0X66f8iWkWfR0S/sarACJrI=
-knative.dev/networking v0.0.0-20210204170711-b61da138ba21 h1:SnCbdGLtfdiUXhg5F8RGrMRUN33tNu+Yd/kF16MNz6I=
-knative.dev/networking v0.0.0-20210204170711-b61da138ba21/go.mod h1:Dl70Ul8xiCleoXGA2unSbfDvJN2oUfZXqVYsE6zl/rM=
+knative.dev/networking v0.0.0-20210208003533-45b7ed13aeaa h1:618cv8suiExQsAkFIgZNf6vfSqpGHI0y09aGokNWEzA=
+knative.dev/networking v0.0.0-20210208003533-45b7ed13aeaa/go.mod h1:Dl70Ul8xiCleoXGA2unSbfDvJN2oUfZXqVYsE6zl/rM=
 knative.dev/pkg v0.0.0-20210203171706-6045ed499615/go.mod h1:X4NPrCo8NK3hbDVan9Vm7mf5io3ZoINakAdrpSXVB08=
 knative.dev/pkg v0.0.0-20210204171111-887806985c09 h1:GD7vfWNgJ9Yy6X9SxXJJj5+NSIg7/hOgNZCzQfHqIQI=
 knative.dev/pkg v0.0.0-20210204171111-887806985c09/go.mod h1:amlT9gE0VkgM+KDt2+i9Eo2y945AjCKh/My9FODy10w=

--- a/hack/tools.go
+++ b/hack/tools.go
@@ -25,6 +25,7 @@ import (
 	_ "knative.dev/networking/test/conformance/ingress"
 	_ "knative.dev/networking/test/test_images/grpc-ping"
 	_ "knative.dev/networking/test/test_images/httpproxy"
+	_ "knative.dev/networking/test/test_images/retry"
 	_ "knative.dev/networking/test/test_images/runtime"
 	_ "knative.dev/networking/test/test_images/timeout"
 	_ "knative.dev/networking/test/test_images/wsserver"

--- a/pkg/reconciler/contour/resources/httpproxy.go
+++ b/pkg/reconciler/contour/resources/httpproxy.go
@@ -21,7 +21,6 @@ import (
 	// nolint:gosec // No strong cryptography needed.
 	"crypto/sha1"
 	"fmt"
-	"net/http"
 	"sort"
 	"strings"
 
@@ -92,9 +91,6 @@ func defaultRetryPolicy() *v1.RetryPolicy {
 			// also retry connection resets.
 			"reset",
 		},
-		RetriableStatusCodes: []uint32{
-			http.StatusServiceUnavailable,
-		},
 	}
 }
 
@@ -134,16 +130,6 @@ func MakeHTTPProxies(ctx context.Context, ing *v1alpha1.Ingress, serviceToProtoc
 			// https://istio.io/latest/docs/concepts/traffic-management/#retries
 			// However, in addition to the codes specified by istio
 			retry := defaultRetryPolicy()
-			if path.DeprecatedRetries != nil && path.DeprecatedRetries.Attempts > 0 {
-				retry.NumRetries = int64(path.DeprecatedRetries.Attempts)
-
-				// When retries is specified explicitly, then we retry some http-level failures as well.
-				retry.RetryOn = append(retry.RetryOn, "5xx")
-
-				if path.DeprecatedRetries.PerTryTimeout != nil {
-					retry.PerTryTimeout = path.DeprecatedRetries.PerTryTimeout.Duration.String()
-				}
-			}
 
 			preSplitHeaders := &v1.HeadersPolicy{
 				Set: make([]v1.HeaderValue, 0, len(path.AppendHeaders)),

--- a/pkg/reconciler/contour/resources/httpproxy.go
+++ b/pkg/reconciler/contour/resources/httpproxy.go
@@ -21,6 +21,7 @@ import (
 	// nolint:gosec // No strong cryptography needed.
 	"crypto/sha1"
 	"fmt"
+	"net/http"
 	"sort"
 	"strings"
 
@@ -77,6 +78,26 @@ func ServiceNames(ctx context.Context, ing *v1alpha1.Ingress) map[string]Service
 	return s
 }
 
+func defaultRetryPolicy() *v1.RetryPolicy {
+	return &v1.RetryPolicy{
+		NumRetries: 2,
+		RetryOn: []v1.RetryOn{
+			"cancelled",
+			"connect-failure",
+			"refused-stream",
+			"resource-exhausted",
+			"retriable-status-codes",
+
+			// In addition to what Istio specifies (above),
+			// also retry connection resets.
+			"reset",
+		},
+		RetriableStatusCodes: []uint32{
+			http.StatusServiceUnavailable,
+		},
+	}
+}
+
 func MakeHTTPProxies(ctx context.Context, ing *v1alpha1.Ingress, serviceToProtocol map[string]string) []*v1.HTTPProxy {
 	ing = ing.DeepCopy()
 	ingress.InsertProbe(ing)
@@ -106,6 +127,22 @@ func MakeHTTPProxies(ctx context.Context, ing *v1alpha1.Ingress, serviceToProtoc
 			top := &v1.TimeoutPolicy{
 				Response: config.FromContext(ctx).Contour.TimeoutPolicyResponse,
 				Idle:     config.FromContext(ctx).Contour.TimeoutPolicyIdle,
+			}
+
+			// By default retry on connection problems twice.
+			// This matches the default behavior of Istio:
+			// https://istio.io/latest/docs/concepts/traffic-management/#retries
+			// However, in addition to the codes specified by istio
+			retry := defaultRetryPolicy()
+			if path.DeprecatedRetries != nil && path.DeprecatedRetries.Attempts > 0 {
+				retry.NumRetries = int64(path.DeprecatedRetries.Attempts)
+
+				// When retries is specified explicitly, then we retry some http-level failures as well.
+				retry.RetryOn = append(retry.RetryOn, "5xx")
+
+				if path.DeprecatedRetries.PerTryTimeout != nil {
+					retry.PerTryTimeout = path.DeprecatedRetries.PerTryTimeout.Duration.String()
+				}
 			}
 
 			preSplitHeaders := &v1.HeadersPolicy{
@@ -196,6 +233,7 @@ func MakeHTTPProxies(ctx context.Context, ing *v1alpha1.Ingress, serviceToProtoc
 			routes = append(routes, v1.Route{
 				Conditions:           conditions,
 				TimeoutPolicy:        top,
+				RetryPolicy:          retry,
 				Services:             svcs,
 				EnableWebsockets:     true,
 				RequestHeadersPolicy: preSplitHeaders,

--- a/pkg/reconciler/contour/resources/httpproxy_test.go
+++ b/pkg/reconciler/contour/resources/httpproxy_test.go
@@ -18,6 +18,7 @@ package resources
 
 import (
 	"context"
+	"net/http"
 	"testing"
 	"time"
 
@@ -125,6 +126,7 @@ func TestMakeProxies(t *testing.T) {
 						Response: "infinity",
 						Idle:     "infinity",
 					},
+					RetryPolicy: defaultRetryPolicy(),
 					Conditions: []v1.MatchCondition{{
 						Header: &v1.HeaderMatchCondition{
 							Name:  "K-Network-Hash",
@@ -172,6 +174,7 @@ func TestMakeProxies(t *testing.T) {
 						Response: "infinity",
 						Idle:     "infinity",
 					},
+					RetryPolicy: defaultRetryPolicy(),
 					RequestHeadersPolicy: &v1.HeadersPolicy{
 						Set: []v1.HeaderValue{{
 							Name:  "Foo",
@@ -265,6 +268,7 @@ func TestMakeProxies(t *testing.T) {
 						Response: "infinity",
 						Idle:     "infinity",
 					},
+					RetryPolicy: defaultRetryPolicy(),
 					Conditions: []v1.MatchCondition{{
 						Header: &v1.HeaderMatchCondition{
 							Name:  "K-Network-Hash",
@@ -290,6 +294,7 @@ func TestMakeProxies(t *testing.T) {
 						Response: "infinity",
 						Idle:     "infinity",
 					},
+					RetryPolicy: defaultRetryPolicy(),
 					RequestHeadersPolicy: &v1.HeadersPolicy{
 						Set: []v1.HeaderValue{},
 					},
@@ -333,6 +338,7 @@ func TestMakeProxies(t *testing.T) {
 						Response: "infinity",
 						Idle:     "infinity",
 					},
+					RetryPolicy: defaultRetryPolicy(),
 					Conditions: []v1.MatchCondition{{
 						Header: &v1.HeaderMatchCondition{
 							Name:  "K-Network-Hash",
@@ -358,6 +364,7 @@ func TestMakeProxies(t *testing.T) {
 						Response: "infinity",
 						Idle:     "infinity",
 					},
+					RetryPolicy: defaultRetryPolicy(),
 					RequestHeadersPolicy: &v1.HeadersPolicy{
 						Set: []v1.HeaderValue{},
 					},
@@ -401,6 +408,7 @@ func TestMakeProxies(t *testing.T) {
 						Response: "infinity",
 						Idle:     "infinity",
 					},
+					RetryPolicy: defaultRetryPolicy(),
 					Conditions: []v1.MatchCondition{{
 						Header: &v1.HeaderMatchCondition{
 							Name:  "K-Network-Hash",
@@ -426,6 +434,7 @@ func TestMakeProxies(t *testing.T) {
 						Response: "infinity",
 						Idle:     "infinity",
 					},
+					RetryPolicy: defaultRetryPolicy(),
 					RequestHeadersPolicy: &v1.HeadersPolicy{
 						Set: []v1.HeaderValue{},
 					},
@@ -495,6 +504,22 @@ func TestMakeProxies(t *testing.T) {
 				Routes: []v1.Route{{
 					EnableWebsockets: true,
 					PermitInsecure:   true,
+					RetryPolicy: &v1.RetryPolicy{
+						NumRetries:    34,
+						PerTryTimeout: "14m0s",
+						RetryOn: []v1.RetryOn{
+							"cancelled",
+							"connect-failure",
+							"refused-stream",
+							"resource-exhausted",
+							"retriable-status-codes",
+							"reset",
+							"5xx",
+						},
+						RetriableStatusCodes: []uint32{
+							http.StatusServiceUnavailable,
+						},
+					},
 					TimeoutPolicy: &v1.TimeoutPolicy{
 						Response: "infinity",
 						Idle:     "infinity",
@@ -520,6 +545,22 @@ func TestMakeProxies(t *testing.T) {
 				}, {
 					EnableWebsockets: true,
 					PermitInsecure:   true,
+					RetryPolicy: &v1.RetryPolicy{
+						NumRetries:    34,
+						PerTryTimeout: "14m0s",
+						RetryOn: []v1.RetryOn{
+							"cancelled",
+							"connect-failure",
+							"refused-stream",
+							"resource-exhausted",
+							"retriable-status-codes",
+							"reset",
+							"5xx",
+						},
+						RetriableStatusCodes: []uint32{
+							http.StatusServiceUnavailable,
+						},
+					},
 					TimeoutPolicy: &v1.TimeoutPolicy{
 						Response: "infinity",
 						Idle:     "infinity",
@@ -626,6 +667,7 @@ func TestMakeProxies(t *testing.T) {
 						Response: "infinity",
 						Idle:     "infinity",
 					},
+					RetryPolicy: defaultRetryPolicy(),
 					RequestHeadersPolicy: &v1.HeadersPolicy{
 						Set: []v1.HeaderValue{{
 							Name:  "K-Network-Hash",
@@ -658,6 +700,7 @@ func TestMakeProxies(t *testing.T) {
 						Response: "infinity",
 						Idle:     "infinity",
 					},
+					RetryPolicy: defaultRetryPolicy(),
 					RequestHeadersPolicy: &v1.HeadersPolicy{
 						Set: []v1.HeaderValue{{
 							Name:  "K-Network-Hash",
@@ -684,6 +727,7 @@ func TestMakeProxies(t *testing.T) {
 						Response: "infinity",
 						Idle:     "infinity",
 					},
+					RetryPolicy: defaultRetryPolicy(),
 					RequestHeadersPolicy: &v1.HeadersPolicy{
 						Set: []v1.HeaderValue{},
 					},
@@ -708,6 +752,7 @@ func TestMakeProxies(t *testing.T) {
 						Response: "infinity",
 						Idle:     "infinity",
 					},
+					RetryPolicy: defaultRetryPolicy(),
 					RequestHeadersPolicy: &v1.HeadersPolicy{
 						Set: []v1.HeaderValue{},
 					},
@@ -800,6 +845,7 @@ func TestMakeProxies(t *testing.T) {
 						Response: "infinity",
 						Idle:     "infinity",
 					},
+					RetryPolicy: defaultRetryPolicy(),
 					Conditions: []v1.MatchCondition{{
 						Header: &v1.HeaderMatchCondition{
 							Name:  "K-Network-Hash",
@@ -844,6 +890,7 @@ func TestMakeProxies(t *testing.T) {
 						Response: "infinity",
 						Idle:     "infinity",
 					},
+					RetryPolicy: defaultRetryPolicy(),
 					RequestHeadersPolicy: &v1.HeadersPolicy{
 						Set: []v1.HeaderValue{{
 							Name:  "Foo",
@@ -956,6 +1003,7 @@ func TestMakeProxies(t *testing.T) {
 						Response: "infinity",
 						Idle:     "infinity",
 					},
+					RetryPolicy: defaultRetryPolicy(),
 					Conditions: []v1.MatchCondition{{
 						Header: &v1.HeaderMatchCondition{
 							Name:  "K-Network-Hash",
@@ -1000,6 +1048,7 @@ func TestMakeProxies(t *testing.T) {
 						Response: "infinity",
 						Idle:     "infinity",
 					},
+					RetryPolicy: defaultRetryPolicy(),
 					RequestHeadersPolicy: &v1.HeadersPolicy{
 						Set: []v1.HeaderValue{{
 							Name:  "Foo",
@@ -1100,6 +1149,7 @@ func TestMakeProxies(t *testing.T) {
 						Response: "infinity",
 						Idle:     "infinity",
 					},
+					RetryPolicy: defaultRetryPolicy(),
 					Conditions: []v1.MatchCondition{{
 						Header: &v1.HeaderMatchCondition{
 							Name:  "K-Network-Hash",
@@ -1131,6 +1181,7 @@ func TestMakeProxies(t *testing.T) {
 						Response: "infinity",
 						Idle:     "infinity",
 					},
+					RetryPolicy: defaultRetryPolicy(),
 					RequestHeadersPolicy: &v1.HeadersPolicy{
 						Set: []v1.HeaderValue{},
 					},
@@ -1213,6 +1264,7 @@ func TestMakeProxies(t *testing.T) {
 						Response: "60s",
 						Idle:     "60s",
 					},
+					RetryPolicy: defaultRetryPolicy(),
 					Conditions: []v1.MatchCondition{{
 						Header: &v1.HeaderMatchCondition{
 							Name:  "K-Network-Hash",
@@ -1244,6 +1296,7 @@ func TestMakeProxies(t *testing.T) {
 						Response: "60s",
 						Idle:     "60s",
 					},
+					RetryPolicy: defaultRetryPolicy(),
 					RequestHeadersPolicy: &v1.HeadersPolicy{
 						Set: []v1.HeaderValue{},
 					},
@@ -1323,6 +1376,7 @@ func TestMakeProxies(t *testing.T) {
 						Response: "infinity",
 						Idle:     "infinity",
 					},
+					RetryPolicy: defaultRetryPolicy(),
 					Conditions: []v1.MatchCondition{{
 						Header: &v1.HeaderMatchCondition{
 							Name:  "K-Network-Hash",
@@ -1357,6 +1411,7 @@ func TestMakeProxies(t *testing.T) {
 						Response: "infinity",
 						Idle:     "infinity",
 					},
+					RetryPolicy: defaultRetryPolicy(),
 					RequestHeadersPolicy: &v1.HeadersPolicy{
 						Set: []v1.HeaderValue{{
 							Name:  "Host",

--- a/pkg/reconciler/contour/resources/httpproxy_test.go
+++ b/pkg/reconciler/contour/resources/httpproxy_test.go
@@ -18,7 +18,6 @@ package resources
 
 import (
 	"context"
-	"net/http"
 	"testing"
 	"time"
 
@@ -126,7 +125,6 @@ func TestMakeProxies(t *testing.T) {
 						Response: "infinity",
 						Idle:     "infinity",
 					},
-					RetryPolicy: defaultRetryPolicy(),
 					Conditions: []v1.MatchCondition{{
 						Header: &v1.HeaderMatchCondition{
 							Name:  "K-Network-Hash",
@@ -174,7 +172,6 @@ func TestMakeProxies(t *testing.T) {
 						Response: "infinity",
 						Idle:     "infinity",
 					},
-					RetryPolicy: defaultRetryPolicy(),
 					RequestHeadersPolicy: &v1.HeadersPolicy{
 						Set: []v1.HeaderValue{{
 							Name:  "Foo",
@@ -268,7 +265,6 @@ func TestMakeProxies(t *testing.T) {
 						Response: "infinity",
 						Idle:     "infinity",
 					},
-					RetryPolicy: defaultRetryPolicy(),
 					Conditions: []v1.MatchCondition{{
 						Header: &v1.HeaderMatchCondition{
 							Name:  "K-Network-Hash",
@@ -294,7 +290,6 @@ func TestMakeProxies(t *testing.T) {
 						Response: "infinity",
 						Idle:     "infinity",
 					},
-					RetryPolicy: defaultRetryPolicy(),
 					RequestHeadersPolicy: &v1.HeadersPolicy{
 						Set: []v1.HeaderValue{},
 					},
@@ -338,7 +333,6 @@ func TestMakeProxies(t *testing.T) {
 						Response: "infinity",
 						Idle:     "infinity",
 					},
-					RetryPolicy: defaultRetryPolicy(),
 					Conditions: []v1.MatchCondition{{
 						Header: &v1.HeaderMatchCondition{
 							Name:  "K-Network-Hash",
@@ -364,7 +358,6 @@ func TestMakeProxies(t *testing.T) {
 						Response: "infinity",
 						Idle:     "infinity",
 					},
-					RetryPolicy: defaultRetryPolicy(),
 					RequestHeadersPolicy: &v1.HeadersPolicy{
 						Set: []v1.HeaderValue{},
 					},
@@ -408,7 +401,6 @@ func TestMakeProxies(t *testing.T) {
 						Response: "infinity",
 						Idle:     "infinity",
 					},
-					RetryPolicy: defaultRetryPolicy(),
 					Conditions: []v1.MatchCondition{{
 						Header: &v1.HeaderMatchCondition{
 							Name:  "K-Network-Hash",
@@ -434,7 +426,6 @@ func TestMakeProxies(t *testing.T) {
 						Response: "infinity",
 						Idle:     "infinity",
 					},
-					RetryPolicy: defaultRetryPolicy(),
 					RequestHeadersPolicy: &v1.HeadersPolicy{
 						Set: []v1.HeaderValue{},
 					},
@@ -504,22 +495,6 @@ func TestMakeProxies(t *testing.T) {
 				Routes: []v1.Route{{
 					EnableWebsockets: true,
 					PermitInsecure:   true,
-					RetryPolicy: &v1.RetryPolicy{
-						NumRetries:    34,
-						PerTryTimeout: "14m0s",
-						RetryOn: []v1.RetryOn{
-							"cancelled",
-							"connect-failure",
-							"refused-stream",
-							"resource-exhausted",
-							"retriable-status-codes",
-							"reset",
-							"5xx",
-						},
-						RetriableStatusCodes: []uint32{
-							http.StatusServiceUnavailable,
-						},
-					},
 					TimeoutPolicy: &v1.TimeoutPolicy{
 						Response: "infinity",
 						Idle:     "infinity",
@@ -545,22 +520,6 @@ func TestMakeProxies(t *testing.T) {
 				}, {
 					EnableWebsockets: true,
 					PermitInsecure:   true,
-					RetryPolicy: &v1.RetryPolicy{
-						NumRetries:    34,
-						PerTryTimeout: "14m0s",
-						RetryOn: []v1.RetryOn{
-							"cancelled",
-							"connect-failure",
-							"refused-stream",
-							"resource-exhausted",
-							"retriable-status-codes",
-							"reset",
-							"5xx",
-						},
-						RetriableStatusCodes: []uint32{
-							http.StatusServiceUnavailable,
-						},
-					},
 					TimeoutPolicy: &v1.TimeoutPolicy{
 						Response: "infinity",
 						Idle:     "infinity",
@@ -667,7 +626,6 @@ func TestMakeProxies(t *testing.T) {
 						Response: "infinity",
 						Idle:     "infinity",
 					},
-					RetryPolicy: defaultRetryPolicy(),
 					RequestHeadersPolicy: &v1.HeadersPolicy{
 						Set: []v1.HeaderValue{{
 							Name:  "K-Network-Hash",
@@ -700,7 +658,6 @@ func TestMakeProxies(t *testing.T) {
 						Response: "infinity",
 						Idle:     "infinity",
 					},
-					RetryPolicy: defaultRetryPolicy(),
 					RequestHeadersPolicy: &v1.HeadersPolicy{
 						Set: []v1.HeaderValue{{
 							Name:  "K-Network-Hash",
@@ -727,7 +684,6 @@ func TestMakeProxies(t *testing.T) {
 						Response: "infinity",
 						Idle:     "infinity",
 					},
-					RetryPolicy: defaultRetryPolicy(),
 					RequestHeadersPolicy: &v1.HeadersPolicy{
 						Set: []v1.HeaderValue{},
 					},
@@ -752,7 +708,6 @@ func TestMakeProxies(t *testing.T) {
 						Response: "infinity",
 						Idle:     "infinity",
 					},
-					RetryPolicy: defaultRetryPolicy(),
 					RequestHeadersPolicy: &v1.HeadersPolicy{
 						Set: []v1.HeaderValue{},
 					},
@@ -845,7 +800,6 @@ func TestMakeProxies(t *testing.T) {
 						Response: "infinity",
 						Idle:     "infinity",
 					},
-					RetryPolicy: defaultRetryPolicy(),
 					Conditions: []v1.MatchCondition{{
 						Header: &v1.HeaderMatchCondition{
 							Name:  "K-Network-Hash",
@@ -890,7 +844,6 @@ func TestMakeProxies(t *testing.T) {
 						Response: "infinity",
 						Idle:     "infinity",
 					},
-					RetryPolicy: defaultRetryPolicy(),
 					RequestHeadersPolicy: &v1.HeadersPolicy{
 						Set: []v1.HeaderValue{{
 							Name:  "Foo",
@@ -1003,7 +956,6 @@ func TestMakeProxies(t *testing.T) {
 						Response: "infinity",
 						Idle:     "infinity",
 					},
-					RetryPolicy: defaultRetryPolicy(),
 					Conditions: []v1.MatchCondition{{
 						Header: &v1.HeaderMatchCondition{
 							Name:  "K-Network-Hash",
@@ -1048,7 +1000,6 @@ func TestMakeProxies(t *testing.T) {
 						Response: "infinity",
 						Idle:     "infinity",
 					},
-					RetryPolicy: defaultRetryPolicy(),
 					RequestHeadersPolicy: &v1.HeadersPolicy{
 						Set: []v1.HeaderValue{{
 							Name:  "Foo",
@@ -1149,7 +1100,6 @@ func TestMakeProxies(t *testing.T) {
 						Response: "infinity",
 						Idle:     "infinity",
 					},
-					RetryPolicy: defaultRetryPolicy(),
 					Conditions: []v1.MatchCondition{{
 						Header: &v1.HeaderMatchCondition{
 							Name:  "K-Network-Hash",
@@ -1181,7 +1131,6 @@ func TestMakeProxies(t *testing.T) {
 						Response: "infinity",
 						Idle:     "infinity",
 					},
-					RetryPolicy: defaultRetryPolicy(),
 					RequestHeadersPolicy: &v1.HeadersPolicy{
 						Set: []v1.HeaderValue{},
 					},
@@ -1264,7 +1213,6 @@ func TestMakeProxies(t *testing.T) {
 						Response: "60s",
 						Idle:     "60s",
 					},
-					RetryPolicy: defaultRetryPolicy(),
 					Conditions: []v1.MatchCondition{{
 						Header: &v1.HeaderMatchCondition{
 							Name:  "K-Network-Hash",
@@ -1296,7 +1244,6 @@ func TestMakeProxies(t *testing.T) {
 						Response: "60s",
 						Idle:     "60s",
 					},
-					RetryPolicy: defaultRetryPolicy(),
 					RequestHeadersPolicy: &v1.HeadersPolicy{
 						Set: []v1.HeaderValue{},
 					},
@@ -1376,7 +1323,6 @@ func TestMakeProxies(t *testing.T) {
 						Response: "infinity",
 						Idle:     "infinity",
 					},
-					RetryPolicy: defaultRetryPolicy(),
 					Conditions: []v1.MatchCondition{{
 						Header: &v1.HeaderMatchCondition{
 							Name:  "K-Network-Hash",
@@ -1411,7 +1357,6 @@ func TestMakeProxies(t *testing.T) {
 						Response: "infinity",
 						Idle:     "infinity",
 					},
-					RetryPolicy: defaultRetryPolicy(),
 					RequestHeadersPolicy: &v1.HeadersPolicy{
 						Set: []v1.HeaderValue{{
 							Name:  "Host",

--- a/pkg/reconciler/contour/resources/httpproxy_test.go
+++ b/pkg/reconciler/contour/resources/httpproxy_test.go
@@ -18,9 +18,7 @@ package resources
 
 import (
 	"context"
-	"net/http"
 	"testing"
-	"time"
 
 	"github.com/google/go-cmp/cmp"
 	v1 "github.com/projectcontour/contour/apis/projectcontour/v1"
@@ -435,136 +433,6 @@ func TestMakeProxies(t *testing.T) {
 						Idle:     "infinity",
 					},
 					RetryPolicy: defaultRetryPolicy(),
-					RequestHeadersPolicy: &v1.HeadersPolicy{
-						Set: []v1.HeaderValue{},
-					},
-					Services: []v1.Service{{
-						Name:     "goo",
-						Protocol: &protocol,
-						Port:     123,
-						Weight:   100,
-					}},
-				}},
-			},
-		}},
-	}, {
-		name: "cluster local visibility with retry policy",
-		ing: &v1alpha1.Ingress{
-			ObjectMeta: metav1.ObjectMeta{
-				Namespace: "foo",
-				Name:      "bar",
-			},
-			Spec: v1alpha1.IngressSpec{
-				Rules: []v1alpha1.IngressRule{{
-					Hosts:      []string{"example.com"},
-					Visibility: v1alpha1.IngressVisibilityClusterLocal,
-					HTTP: &v1alpha1.HTTPIngressRuleValue{
-						Paths: []v1alpha1.HTTPIngressPath{{
-							DeprecatedRetries: &v1alpha1.HTTPRetry{
-								Attempts:      34,
-								PerTryTimeout: &metav1.Duration{Duration: 14 * time.Minute},
-							},
-							Splits: []v1alpha1.IngressBackendSplit{{
-								IngressBackend: v1alpha1.IngressBackend{
-									ServiceName: "goo",
-									ServicePort: intstr.FromInt(123),
-								},
-								Percent: 100,
-							}},
-						}},
-					},
-				}},
-			},
-		},
-		want: []*v1.HTTPProxy{{
-			ObjectMeta: metav1.ObjectMeta{
-				Namespace: "foo",
-				Name:      "bar-" + privateClass + "-example.com",
-				Labels: map[string]string{
-					DomainHashKey: "0caaf24ab1a0c33440c06afe99df986365b0781f",
-					GenerationKey: "0",
-					ParentKey:     "bar",
-					ClassKey:      privateClass,
-				},
-				Annotations: map[string]string{
-					ClassKey: privateClass,
-				},
-				OwnerReferences: []metav1.OwnerReference{{
-					APIVersion:         "networking.internal.knative.dev/v1alpha1",
-					Kind:               "Ingress",
-					Name:               "bar",
-					Controller:         ptr.Bool(true),
-					BlockOwnerDeletion: ptr.Bool(true),
-				}},
-			},
-			Spec: v1.HTTPProxySpec{
-				VirtualHost: &v1.VirtualHost{
-					Fqdn: "example.com",
-				},
-				Routes: []v1.Route{{
-					EnableWebsockets: true,
-					PermitInsecure:   true,
-					RetryPolicy: &v1.RetryPolicy{
-						NumRetries:    34,
-						PerTryTimeout: "14m0s",
-						RetryOn: []v1.RetryOn{
-							"cancelled",
-							"connect-failure",
-							"refused-stream",
-							"resource-exhausted",
-							"retriable-status-codes",
-							"reset",
-							"5xx",
-						},
-						RetriableStatusCodes: []uint32{
-							http.StatusServiceUnavailable,
-						},
-					},
-					TimeoutPolicy: &v1.TimeoutPolicy{
-						Response: "infinity",
-						Idle:     "infinity",
-					},
-					Conditions: []v1.MatchCondition{{
-						Header: &v1.HeaderMatchCondition{
-							Name:  "K-Network-Hash",
-							Exact: "override",
-						},
-					}},
-					RequestHeadersPolicy: &v1.HeadersPolicy{
-						Set: []v1.HeaderValue{{
-							Name:  "K-Network-Hash",
-							Value: "9e1b02792803e1cbd5153bea0600879842245f6d263bee0821f4b4be5a55e40f",
-						}},
-					},
-					Services: []v1.Service{{
-						Name:     "goo",
-						Protocol: &protocol,
-						Port:     123,
-						Weight:   100,
-					}},
-				}, {
-					EnableWebsockets: true,
-					PermitInsecure:   true,
-					RetryPolicy: &v1.RetryPolicy{
-						NumRetries:    34,
-						PerTryTimeout: "14m0s",
-						RetryOn: []v1.RetryOn{
-							"cancelled",
-							"connect-failure",
-							"refused-stream",
-							"resource-exhausted",
-							"retriable-status-codes",
-							"reset",
-							"5xx",
-						},
-						RetriableStatusCodes: []uint32{
-							http.StatusServiceUnavailable,
-						},
-					},
-					TimeoutPolicy: &v1.TimeoutPolicy{
-						Response: "infinity",
-						Idle:     "infinity",
-					},
 					RequestHeadersPolicy: &v1.HeadersPolicy{
 						Set: []v1.HeaderValue{},
 					},

--- a/vendor/knative.dev/networking/test/conformance/ingress/retry.go
+++ b/vendor/knative.dev/networking/test/conformance/ingress/retry.go
@@ -1,0 +1,77 @@
+/*
+Copyright 2021 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ingress
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"knative.dev/networking/pkg/apis/networking/v1alpha1"
+	"knative.dev/networking/test"
+)
+
+// TestRetry verifies that the ingress does not retry failed requests.
+func TestRetry(t *testing.T) {
+	t.Parallel()
+	ctx, clients := context.Background(), test.Setup(t)
+	name, port, _ := CreateRetryService(ctx, t, clients)
+	domain := name + ".example.com"
+
+	// Create a simple Ingress over the Service.
+	_, client, _ := CreateIngressReady(ctx, t, clients, v1alpha1.IngressSpec{
+		Rules: []v1alpha1.IngressRule{{
+			Hosts:      []string{domain},
+			Visibility: v1alpha1.IngressVisibilityExternalIP,
+			HTTP: &v1alpha1.HTTPIngressRuleValue{
+				Paths: []v1alpha1.HTTPIngressPath{{
+					Splits: []v1alpha1.IngressBackendSplit{{
+						IngressBackend: v1alpha1.IngressBackend{
+							ServiceName:      name,
+							ServiceNamespace: test.ServingNamespace,
+							ServicePort:      intstr.FromInt(port),
+						},
+					}},
+				}},
+			},
+		}},
+	})
+
+	// First try - we expect this to fail, because we shouldn't retry
+	// automatically and the service only responds 200 on the _second_ access.
+	resp, err := client.Get("http://" + domain)
+	if err != nil {
+		t.Errorf("Error making GET request: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusServiceUnavailable {
+		t.Errorf("Got status %d, expected %d", resp.StatusCode, http.StatusServiceUnavailable)
+		DumpResponse(ctx, t, resp)
+	}
+
+	// Second try - this time we should succeed.
+	resp, err = client.Get("http://" + domain)
+	if err != nil {
+		t.Errorf("Error making GET request: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("Got not OK status, expected success: %d", resp.StatusCode)
+		DumpResponse(ctx, t, resp)
+	}
+}

--- a/vendor/knative.dev/networking/test/conformance/ingress/run.go
+++ b/vendor/knative.dev/networking/test/conformance/ingress/run.go
@@ -36,6 +36,7 @@ var stableTests = map[string]func(t *testing.T){
 	"dispatch/percentage":          TestPercentage,
 	"dispatch/path_and_percentage": TestPathAndPercentageSplit,
 	"dispatch/rule":                TestRule,
+	"retry":                        TestRetry,
 	"timeout":                      TestTimeout,
 	"tls":                          TestIngressTLS,
 	"update":                       TestUpdate,

--- a/vendor/knative.dev/networking/test/conformance/ingress/util.go
+++ b/vendor/knative.dev/networking/test/conformance/ingress/util.go
@@ -447,6 +447,76 @@ func CreateGRPCService(ctx context.Context, t *testing.T, clients *test.Clients,
 	return name, port, createPodAndService(ctx, t, clients, pod, svc)
 }
 
+// CreateRetryService creates a service that will return a 503 on first access, and then 200 after that.
+func CreateRetryService(ctx context.Context, t *testing.T, clients *test.Clients) (string, int, context.CancelFunc) {
+	t.Helper()
+	name := test.ObjectNameForTest(t)
+
+	// Avoid zero, but pick a low port number.
+	port := 50 + rand.Intn(50)
+	t.Logf("[%s] Using port %d", name, port)
+
+	// Pick a high port number.
+	containerPort := 8000 + rand.Intn(100)
+	t.Logf("[%s] Using containerPort %d", name, containerPort)
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: test.ServingNamespace,
+			Labels: map[string]string{
+				"test-pod": name,
+			},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{{
+				Name:            "foo",
+				Image:           pkgTest.ImagePath("retry"),
+				ImagePullPolicy: corev1.PullIfNotPresent,
+				Ports: []corev1.ContainerPort{{
+					Name:          networking.ServicePortNameH2C,
+					ContainerPort: int32(containerPort),
+				}},
+				// This is needed by the runtime image we are using.
+				Env: []corev1.EnvVar{{
+					Name:  "PORT",
+					Value: strconv.Itoa(containerPort),
+				}},
+				ReadinessProbe: &corev1.Probe{
+					Handler: corev1.Handler{
+						TCPSocket: &corev1.TCPSocketAction{
+							Port: intstr.FromInt(containerPort),
+						},
+					},
+				},
+			}},
+		},
+	}
+
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: test.ServingNamespace,
+			Labels: map[string]string{
+				"test-pod": name,
+			},
+		},
+		Spec: corev1.ServiceSpec{
+			Type: "ClusterIP",
+			Ports: []corev1.ServicePort{{
+				Name:       networking.ServicePortNameH2C,
+				Port:       int32(port),
+				TargetPort: intstr.FromInt(containerPort),
+			}},
+			Selector: map[string]string{
+				"test-pod": name,
+			},
+		},
+	}
+
+	return name, port, createPodAndService(ctx, t, clients, pod, svc)
+}
+
 // createService is a helper for creating the service resource.
 func createService(ctx context.Context, t *testing.T, clients *test.Clients, svc *corev1.Service) context.CancelFunc {
 	t.Helper()

--- a/vendor/knative.dev/networking/test/test_images/retry/main.go
+++ b/vendor/knative.dev/networking/test/test_images/retry/main.go
@@ -1,0 +1,42 @@
+/*
+Copyright 2021 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"os"
+
+	network "knative.dev/networking/pkg"
+	"knative.dev/networking/test"
+)
+
+var retries = 0
+
+func handler(w http.ResponseWriter, r *http.Request) {
+	if retries == 0 {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}
+
+	fmt.Fprintf(w, "Retry %d", retries)
+	retries++
+}
+
+func main() {
+	h := network.NewProbeHandler(http.HandlerFunc(handler))
+	test.ListenAndServeGracefully(":"+os.Getenv("PORT"), h.ServeHTTP)
+}

--- a/vendor/knative.dev/networking/test/test_images/retry/service.yaml
+++ b/vendor/knative.dev/networking/test/test_images/retry/service.yaml
@@ -1,10 +1,10 @@
 apiVersion: serving.knative.dev/v1
 kind: Service
 metadata:
-  name: retry-test-image
+  name: timeout-test-image
   namespace: default
 spec:
   template:
     spec:
       containers:
-      - image: ko://knative.dev/networking/test/test_images/timeout
+      - image: ko://knative.dev/networking/test/test_images/retry

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -898,7 +898,7 @@ k8s.io/utils/trace
 # knative.dev/hack v0.0.0-20210203173706-8368e1f6eacf
 ## explicit
 knative.dev/hack
-# knative.dev/networking v0.0.0-20210204170711-b61da138ba21
+# knative.dev/networking v0.0.0-20210208003533-45b7ed13aeaa
 ## explicit
 knative.dev/networking/pkg
 knative.dev/networking/pkg/apis/networking
@@ -929,6 +929,7 @@ knative.dev/networking/test/defaultsystem
 knative.dev/networking/test/test_images/grpc-ping
 knative.dev/networking/test/test_images/grpc-ping/proto
 knative.dev/networking/test/test_images/httpproxy
+knative.dev/networking/test/test_images/retry
 knative.dev/networking/test/test_images/runtime
 knative.dev/networking/test/test_images/runtime/handlers
 knative.dev/networking/test/test_images/timeout


### PR DESCRIPTION
This patch adds retry test image which was added by
https://github.com/knative/networking/commit/45b7ed13aeaa6276d6399cec0e3354c8acd8dbd0.

/kind cleanup

**Release Note**

```release-note
Removed retry policy which retries when backend returns 503.
```
