### PR TITLE
Use sigs.k8s.io/yaml for YAML operations

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,11 +8,11 @@ require (
 	github.com/mikefarah/yq/v3 v3.0.0-20200601230220-721dd57ed41b
 	github.com/projectcontour/contour v1.12.0
 	go.uber.org/zap v1.16.0
-	gopkg.in/yaml.v2 v2.3.0
 	k8s.io/api v0.19.7
 	k8s.io/apimachinery v0.19.7
 	k8s.io/client-go v0.19.7
 	knative.dev/hack v0.0.0-20210203173706-8368e1f6eacf
 	knative.dev/networking v0.0.0-20210209171856-855092348016
 	knative.dev/pkg v0.0.0-20210208175252-a02dcff9ee26
+	sigs.k8s.io/yaml v1.2.0
 )

--- a/pkg/reconciler/contour/config/contour.go
+++ b/pkg/reconciler/contour/config/contour.go
@@ -20,13 +20,13 @@ import (
 	"fmt"
 	"time"
 
-	"gopkg.in/yaml.v2"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/tools/cache"
 	"knative.dev/networking/pkg/apis/networking/v1alpha1"
 	"knative.dev/pkg/configmap"
+	"sigs.k8s.io/yaml"
 )
 
 const (
@@ -88,7 +88,7 @@ func NewContourFromConfigMap(configMap *corev1.ConfigMap) (*Contour, error) {
 		}, nil
 	}
 	entry := make(map[v1alpha1.IngressVisibility]visibilityValue)
-	if err := yaml.Unmarshal([]byte(v), entry); err != nil {
+	if err := yaml.Unmarshal([]byte(v), &entry); err != nil {
 		return nil, err
 	}
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -517,7 +517,6 @@ gopkg.in/inf.v0
 # gopkg.in/op/go-logging.v1 v1.0.0-20160211212156-b2cb9fa56473
 gopkg.in/op/go-logging.v1
 # gopkg.in/yaml.v2 v2.3.0
-## explicit
 gopkg.in/yaml.v2
 # gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c
 gopkg.in/yaml.v3
@@ -1014,4 +1013,5 @@ sigs.k8s.io/service-apis/apis/v1alpha1
 # sigs.k8s.io/structured-merge-diff/v4 v4.0.1
 sigs.k8s.io/structured-merge-diff/v4/value
 # sigs.k8s.io/yaml v1.2.0
+## explicit
 sigs.k8s.io/yaml


### PR DESCRIPTION
As per title, I recently went through and cleaned a lot of repos where we've been using different YAML libs, sometimes even 2 or 3 in the same repo.

It seemed the best to just align all to the k8s YAML lib, since we're mostly working with YAML in a k8s context anyway.

/assign @mattmoor 