### PR TITLE
Fix typo in config-contour example

### DIFF
--- a/config/config-contour.yaml
+++ b/config/config-contour.yaml
@@ -32,7 +32,7 @@ data:
     timeout-policy-idle: "infinity"
 
     # timeout-policy-response sets TimeoutPolicy.Response in contour HTTPProxy spec
-    timeou-policy-response: "infinity"
+    timeout-policy-response: "infinity"
 
     # If auto-TLS is disabled fallback to the following certificate
     #


### PR DESCRIPTION
# Changes

:bug: just a typo in the example docstring

/kind bug