### PR TITLE
Drop master references to knative repos

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,10 +1,10 @@
 # Development
 
 This doc explains how to setup a development environment so you can get started
-[contributing](https://github.com/knative/docs/blob/master/community/CONTRIBUTING.md)
+[contributing](https://github.com/knative/docs/blob/main/community/CONTRIBUTING.md)
 to Knative `net-contour`. Also take a look at:
 
-- [The pull request workflow](https://github.com/knative/docs/blob/master/community/CONTRIBUTING.md#pull-requests)
+- [The pull request workflow](https://github.com/knative/docs/blob/main/community/CONTRIBUTING.md#pull-requests)
 
 ## Getting started
 

--- a/hack/release.sh
+++ b/hack/release.sh
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 # Documentation about this script and how to use it can be found
-# at https://github.com/knative/test-infra/tree/master/ci
+# at https://github.com/knative/hack#using-the-releasesh-helper-script
 
 source $(dirname $0)/../vendor/knative.dev/hack/release.sh
 


### PR DESCRIPTION
As per title, this bends all references to the now correct ones.

/assign @dprotaso 