### PR TITLE
Clarify that rule paths should be prefix matched

### DIFF
--- a/pkg/reconciler/contour/resources/httpproxy.go
+++ b/pkg/reconciler/contour/resources/httpproxy.go
@@ -187,9 +187,6 @@ func MakeHTTPProxies(ctx context.Context, ing *v1alpha1.Ingress, serviceToProtoc
 			var conditions []v1.MatchCondition
 			if path.Path != "" {
 				conditions = append(conditions, v1.MatchCondition{
-					// This is technically not accurate since it's not a prefix,
-					// but a regular expression, however, all usage is either empty
-					// or absolute paths.
 					Prefix: path.Path,
 				})
 			}


### PR DESCRIPTION
Per https://github.com/knative/networking/pull/364, rule paths should be prefix matches and not regular expressions, so the current behavior used here is fine. This PR just updates the doc comment so that there's no confusion about the implementation choice.