### PR TITLE
Change certgen imagePullPolicy to IfNotPresent

### DIFF
--- a/config/contour/external.yaml
+++ b/config/contour/external.yaml
@@ -1812,7 +1812,7 @@ spec:
       containers:
         - name: contour
           image: ko://github.com/projectcontour/contour/cmd/contour
-          imagePullPolicy: Always
+          imagePullPolicy: IfNotPresent
           command:
             - contour
             - certgen

--- a/config/contour/internal.yaml
+++ b/config/contour/internal.yaml
@@ -1812,7 +1812,7 @@ spec:
       containers:
         - name: contour
           image: ko://github.com/projectcontour/contour/cmd/contour
-          imagePullPolicy: Always
+          imagePullPolicy: IfNotPresent
           command:
             - contour
             - certgen

--- a/hack/update-deps.sh
+++ b/hack/update-deps.sh
@@ -56,6 +56,10 @@ function rewrite_image() {
   sed -E $'s@docker.io/projectcontour/contour:.+@ko://github.com/projectcontour/contour/cmd/contour@g'
 }
 
+function rewrite_image_pull_policy() {
+  sed -E $'s@imagePullPolicy: Always@imagePullPolicy: IfNotPresent@g'
+}
+
 function rewrite_command() {
   sed -e $'s@/bin/contour@contour@g'
 }
@@ -104,7 +108,7 @@ contour_yaml \
   | delete_contour_cluster_role_bindings \
   | rewrite_contour_namespace contour-internal \
   | rewrite_serve_args contour-internal | rewrite_user \
-  | rewrite_image | rewrite_command | disable_hostport | privatize_loadbalancer \
+  | rewrite_image | rewrite_image_pull_policy | rewrite_command | disable_hostport | privatize_loadbalancer \
   | add_ingress_provider_labels  >> config/contour/internal.yaml
 
 # We do this manually because it's challenging to rewrite
@@ -131,5 +135,5 @@ contour_yaml \
   | delete_contour_cluster_role_bindings \
   | rewrite_contour_namespace contour-external \
   | rewrite_serve_args contour-external | rewrite_user \
-  | rewrite_image | rewrite_command | disable_hostport \
+  | rewrite_image | rewrite_image_pull_policy | rewrite_command | disable_hostport \
   | add_ingress_provider_labels >> config/contour/external.yaml


### PR DESCRIPTION
# Changes

- :broom: Switch certgen job to use `imagePullPolicy: IfNotPresent` instead of `Always`

Upstream they use a mutable :latest tag, but since we are using ko it
will be fully resolved.

https://github.com/projectcontour/contour/pull/2545

This is sorta a bug, if you try to use `kind.local` as your `KO_DOCKER_REPO` you'll get image pull errors for this job.

/kind enhancement