### PR TITLE
rename ClusterRole to differ from existing contour installation

### DIFF
--- a/config/contour/external.yaml
+++ b/config/contour/external.yaml
@@ -1,13 +1,13 @@
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
-  name: contour-external
+  name: contour-external-crb
   labels:
     networking.knative.dev/ingress-provider: contour
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: contour
+  name: contour-knative
 subjects:
 - kind: ServiceAccount
   name: contour
@@ -1840,7 +1840,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   creationTimestamp: null
-  name: contour
+  name: contour-knative
   labels:
     networking.knative.dev/ingress-provider: contour
 rules:

--- a/config/contour/internal.yaml
+++ b/config/contour/internal.yaml
@@ -1,13 +1,13 @@
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
-  name: contour-internal
+  name: contour-internal-crb
   labels:
     networking.knative.dev/ingress-provider: contour
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: contour
+  name: contour-knative
 subjects:
 - kind: ServiceAccount
   name: contour
@@ -1840,7 +1840,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   creationTimestamp: null
-  name: contour
+  name: contour-knative
   labels:
     networking.knative.dev/ingress-provider: contour
 rules:

--- a/hack/update-deps.sh
+++ b/hack/update-deps.sh
@@ -22,6 +22,8 @@ source $(dirname "$0")/../vendor/knative.dev/hack/library.sh
 
 CONTOUR_VERSION="v1.14.0" # This is for controlling which version of contour we want to use.
 
+CLUSTER_ROLE_NAME=contour-knative
+
 FLOATING_DEPS=(
   "github.com/projectcontour/contour@${CONTOUR_VERSION}"
 )
@@ -41,6 +43,10 @@ function add_ingress_provider_labels() {
 
 function delete_contour_cluster_role_bindings() {
   sed -e '/apiVersion: rbac.authorization.k8s.io/{' -e ':a' -e '${' -e 'p' -e 'd'  -e '}' -e 'N' -e '/---/!ba' -e '/kind: ClusterRoleBinding/d' -e '}'
+}
+
+function rename_cluster_role() {
+  sed -e "/apiVersion: rbac.authorization.k8s.io/{N;/kind: ClusterRole\b/{N;N;N;s/name: contour/name: $1/}}"
 }
 
 function rewrite_contour_namespace() {
@@ -90,13 +96,13 @@ cat > config/contour/internal.yaml <<EOF
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
-  name: contour-internal
+  name: contour-internal-crb
   labels:
     networking.knative.dev/ingress-provider: contour
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: contour
+  name: $CLUSTER_ROLE_NAME
 subjects:
 - kind: ServiceAccount
   name: contour
@@ -105,6 +111,7 @@ subjects:
 EOF
 
 contour_yaml \
+  | rename_cluster_role $CLUSTER_ROLE_NAME \
   | delete_contour_cluster_role_bindings \
   | rewrite_contour_namespace contour-internal \
   | rewrite_serve_args contour-internal | rewrite_user \
@@ -117,13 +124,13 @@ cat > config/contour/external.yaml <<EOF
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
-  name: contour-external
+  name: contour-external-crb
   labels:
     networking.knative.dev/ingress-provider: contour
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: contour
+  name: $CLUSTER_ROLE_NAME
 subjects:
 - kind: ServiceAccount
   name: contour
@@ -132,6 +139,7 @@ subjects:
 EOF
 
 contour_yaml \
+  | rename_cluster_role $CLUSTER_ROLE_NAME \
   | delete_contour_cluster_role_bindings \
   | rewrite_contour_namespace contour-external \
   | rewrite_serve_args contour-external | rewrite_user \


### PR DESCRIPTION
# Changes

This PR renames a ClusterRole currently called `contour` and updates its references in ClusterRoleBindings. It also renames the two ClusterRoleBindings that reference the renamed ClusterRole, mainly to avoid collateral effects in case you deploy Knative (version containing the ClusterRole renaming change) over an older version. You would get an error due to changes in an immutable field (roleRef).

The motivation for this PR is to minimize changes necessary to have Knative/net-contour/contour alongside with another contour installation. Currently, if a tool like `kapp` is used to install Knative or Contour, you will get an ownership error because another app already owns a ClusterRole called `contour`.

:broom: Update or clean up current behavior

/kind enhancement

Fixes #495
