### PR TITLE
Rename ClusterRole and ClusterRoleBinding to differ from existing contour installation

### DIFF
--- a/config/contour/external.yaml
+++ b/config/contour/external.yaml
@@ -1,13 +1,13 @@
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
-  name: contour-external
+  name: knative-contour-external
   labels:
     networking.knative.dev/ingress-provider: contour
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: contour
+  name: knative-contour
 subjects:
 - kind: ServiceAccount
   name: contour
@@ -1840,7 +1840,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   creationTimestamp: null
-  name: contour
+  name: knative-contour
   labels:
     networking.knative.dev/ingress-provider: contour
 rules:

--- a/config/contour/internal.yaml
+++ b/config/contour/internal.yaml
@@ -1,13 +1,13 @@
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
-  name: contour-internal
+  name: knative-contour-internal
   labels:
     networking.knative.dev/ingress-provider: contour
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: contour
+  name: knative-contour
 subjects:
 - kind: ServiceAccount
   name: contour
@@ -1840,7 +1840,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   creationTimestamp: null
-  name: contour
+  name: knative-contour
   labels:
     networking.knative.dev/ingress-provider: contour
 rules:


### PR DESCRIPTION
# Changes

This PR renames a ClusterRole currently called `contour` and updates its references in ClusterRoleBindings. It also renames the two ClusterRoleBindings that reference the renamed ClusterRole, mainly to avoid collateral effects in case you deploy Knative (version containing the ClusterRole renaming change) over an older version. You would get an error due to changes in an immutable field (roleRef).

The motivation for this PR is to minimize changes necessary to have Knative/net-contour/contour alongside with another contour installation. Currently, if a tool like `kapp` is used to install Knative or Contour, you will get an ownership error because another app already owns a ClusterRole called `contour`.

PS.: I originally submitted these changes using the [PR#496](https://github.com/knative-sandbox/net-contour/pull/496), but I messed it up 😬  and accidentally closed the PR.

:broom: Update or clean up current behavior

/kind enhancement

Fixes #495
