### PR TITLE
switch to rbac/v1

### DIFF
--- a/config/contour/external.yaml
+++ b/config/contour/external.yaml
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: knative-contour-external

--- a/config/contour/internal.yaml
+++ b/config/contour/internal.yaml
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: knative-contour-internal

--- a/hack/update-deps.sh
+++ b/hack/update-deps.sh
@@ -98,7 +98,7 @@ rm -rf config/contour/*
 # We do this manually because it's challenging to rewrite
 # the ClusterRoleBinding without collateral damage.
 cat > config/contour/internal.yaml <<EOF
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: knative-contour-internal
@@ -126,7 +126,7 @@ contour_yaml \
 # We do this manually because it's challenging to rewrite
 # the ClusterRoleBinding without collateral damage.
 cat > config/contour/external.yaml <<EOF
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: knative-contour-external


### PR DESCRIPTION
`
Warning: rbac.authorization.k8s.io/v1beta1 ClusterRoleBinding is deprecated in v1.17+, unavailable in v1.22+; use rbac.authorization.k8s.io/v1 ClusterRoleBinding
`