### PR TITLE
Cherry-pick fix for CVE-2021-32783 via go.mod replace directive

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,3 +15,5 @@ require (
 	knative.dev/pkg v0.0.0-20210622173328-dd0db4b05c80
 	sigs.k8s.io/yaml v1.2.0
 )
+
+replace github.com/projectcontour/contour => github.com/evankanderson/contour v1.14.1-0.20210727041602-27605333c317

--- a/go.sum
+++ b/go.sum
@@ -186,6 +186,8 @@ github.com/envoyproxy/go-control-plane v0.9.9-0.20210217033140-668b12f5399d h1:Q
 github.com/envoyproxy/go-control-plane v0.9.9-0.20210217033140-668b12f5399d/go.mod h1:cXg6YxExXjJnVBQHBLXeUAgxn2UodCpnH306RInaBQk=
 github.com/envoyproxy/protoc-gen-validate v0.1.0 h1:EQciDnbrYxy13PgWoY8AqoxGiPrpgBZ1R8UNe3ddc+A=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
+github.com/evankanderson/contour v1.14.1-0.20210727041602-27605333c317 h1:A5+2bipOq1m97+db33vd1H7tucC/wJWR/qKRihVBF8U=
+github.com/evankanderson/contour v1.14.1-0.20210727041602-27605333c317/go.mod h1:IrlEYL0KQvvsEw0ZWg+8P21P1OuVLqnAxIMGwkLljJI=
 github.com/evanphx/json-patch v0.5.2/go.mod h1:ZWS5hhDbVDyob71nXKNL0+PWn6ToqBHMikGIFbs31qQ=
 github.com/evanphx/json-patch v4.2.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/evanphx/json-patch v4.5.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
@@ -592,8 +594,6 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndrE9hABlRI=
 github.com/pquerna/cachecontrol v0.0.0-20171018203845-0dec1b30a021/go.mod h1:prYjPmNq4d1NPVmpShWobRqXY3q7Vp+80DqgxxUrUIA=
-github.com/projectcontour/contour v1.14.0 h1:xfMjzI3HuWecfe85qdBluqFRWvTtQuKVK2seZuSTx9E=
-github.com/projectcontour/contour v1.14.0/go.mod h1:IrlEYL0KQvvsEw0ZWg+8P21P1OuVLqnAxIMGwkLljJI=
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
 github.com/prometheus/client_golang v0.9.3-0.20190127221311-3c4408c8b829/go.mod h1:p2iRAGwDERtqlqzRXnrOVns+ignqQo//hLXqYxZYVNs=
 github.com/prometheus/client_golang v0.9.3/go.mod h1:/TN21ttK/J9q6uSwhBd54HahCDft0ttaMvbicHlPoso=

--- a/vendor/github.com/projectcontour/contour/internal/dag/accessors.go
+++ b/vendor/github.com/projectcontour/contour/internal/dag/accessors.go
@@ -57,6 +57,11 @@ func (dag *DAG) EnsureService(meta types.NamespacedName, port intstr.IntOrString
 		return nil, err
 	}
 
+	err = validateExternalName(svc, false)
+	if err != nil {
+		return nil, err
+	}
+
 	if dagSvc := dag.GetService(k8s.NamespacedNameOf(svc), svcPort.Port); dagSvc != nil {
 		return dagSvc, nil
 	}
@@ -76,6 +81,38 @@ func (dag *DAG) EnsureService(meta types.NamespacedName, port intstr.IntOrString
 		ExternalName:       externalName(svc),
 	}
 	return dagSvc, nil
+}
+
+func validateExternalName(svc *v1.Service, enableExternalNameSvc bool) error {
+
+	// If this isn't an ExternalName Service, we're all good here.
+	en := externalName(svc)
+	if en == "" {
+		return nil
+	}
+
+	// If ExternalNames are disabled, then we don't want to add this to the DAG.
+	if !enableExternalNameSvc {
+		return fmt.Errorf("%s/%s is an ExternalName service, these are not currently enabled. See the config.enableExternalNameService config file setting", svc.Namespace, svc.Name)
+	}
+
+	// Check against a list of known localhost names, using a map to approximate a set.
+	// TODO(youngnick) This is a very porous hack, and we should probably look into doing a DNS
+	// lookup to check what the externalName resolves to, but I'm worried about the
+	// performance impact of doing one or more DNS lookups per DAG run, so we're
+	// going to go with a specific blocklist for now.
+	localhostNames := map[string]struct{}{
+		"localhost":               {},
+		"localhost.localdomain":   {},
+		"local.projectcontour.io": {},
+	}
+
+	_, localhost := localhostNames[en]
+	if localhost {
+		return fmt.Errorf("%s/%s is an ExternalName service that points to localhost, this is not allowed", svc.Namespace, svc.Name)
+	}
+
+	return nil
 }
 
 func upstreamProtocol(svc *v1.Service, port v1.ServicePort) string {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -235,7 +235,7 @@ github.com/modern-go/reflect2
 github.com/openzipkin/zipkin-go/model
 # github.com/pkg/errors v0.9.1
 github.com/pkg/errors
-# github.com/projectcontour/contour v1.14.0
+# github.com/projectcontour/contour v1.14.0 => github.com/evankanderson/contour v1.14.1-0.20210727041602-27605333c317
 ## explicit
 github.com/projectcontour/contour/apis/projectcontour/v1
 github.com/projectcontour/contour/apis/projectcontour/v1alpha1
@@ -1042,3 +1042,4 @@ sigs.k8s.io/structured-merge-diff/v4/value
 # sigs.k8s.io/yaml v1.2.0
 ## explicit
 sigs.k8s.io/yaml
+# github.com/projectcontour/contour => github.com/evankanderson/contour v1.14.1-0.20210727041602-27605333c317


### PR DESCRIPTION
Replacement for #563.

This is a fix for [CVE-2021-32783](https://github.com/projectcontour/contour/security/advisories/GHSA-5ph6-qq5x-7jwc).

Process: I read https://github.com/projectcontour/contour/compare/v1.17.0...v1.17.1 and attempted to apply the patch to the vendored copy of Contour. Unlike the real fix, I didn't provide a configmap value to override to allow ExternalName services, so an upgrade to 1.17.1 or 1.18 will be needed to re-enable the functionality.

https://github.com/evankanderson/contour/tree/CVE-32783 contains the fix; Contour is only maintaining the latest release branch.

