### PR TITLE
Disable Knative's Contour support for ExternalName K8s Services

### DIFF
--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -198,6 +198,7 @@ jobs:
         # Run the tests tagged as e2e on the KinD cluster.
         go test -race -count=1 -short -timeout=20m -tags=e2e ${{ matrix.test-suite }} \
            --enable-beta --enable-alpha \
+           --skip-tests host-rewrite \
            --ingressClass=contour.ingress.networking.knative.dev \
            --cluster-suffix=$CLUSTER_SUFFIX
 

--- a/config/contour/external.yaml
+++ b/config/contour/external.yaml
@@ -95,7 +95,7 @@ data:
     # You can re-enable them by setting this setting to `true`.
     # This is not recommended without understanding the security implications.
     # Please see the advisory at https://github.com/projectcontour/contour/security/advisories/GHSA-5ph6-qq5x-7jwc for the details.
-    enableExternalNameService: true
+    # enableExternalNameService: false
     ##
     ### Logging options
     # Default setting

--- a/config/contour/internal.yaml
+++ b/config/contour/internal.yaml
@@ -95,7 +95,7 @@ data:
     # You can re-enable them by setting this setting to `true`.
     # This is not recommended without understanding the security implications.
     # Please see the advisory at https://github.com/projectcontour/contour/security/advisories/GHSA-5ph6-qq5x-7jwc for the details.
-    enableExternalNameService: true
+    # enableExternalNameService: false
     ##
     ### Logging options
     # Default setting

--- a/hack/overlays/enable-contour-externalnameservice.yaml
+++ b/hack/overlays/enable-contour-externalnameservice.yaml
@@ -1,9 +1,0 @@
-#@ load("@ytt:overlay", "overlay")
-#@ load("@ytt:data", "data")
-
-#@overlay/match by=overlay.subset({"kind":"ConfigMap","metadata":{"name":"contour"}})
----
-data:
-  #@overlay/replace via=lambda left, right: left.replace("# enableExternalNameService: false", right)
-  #@yaml/text-templated-strings
-  contour.yaml: "enableExternalNameService: true"

--- a/pkg/reconciler/contour/contour.go
+++ b/pkg/reconciler/contour/contour.go
@@ -310,7 +310,7 @@ func (r *Reconciler) lbStatus(ctx context.Context, vis v1alpha1.IngressVisibilit
 			if service, err := r.serviceLister.Services(namespace).Get(name); err == nil {
 				clusterIP = service.Spec.ClusterIP
 			} else {
-				logger.Infof("failed to get service to determine cluster IP %s", err)
+				logger.Infof("failed to get service to determine cluster IP", zap.Error(err))
 			}
 
 			lbs = append(lbs, v1alpha1.LoadBalancerIngressStatus{

--- a/pkg/reconciler/contour/contour_test.go
+++ b/pkg/reconciler/contour/contour_test.go
@@ -127,9 +127,11 @@ func TestReconcile(t *testing.T) {
 				i.Status.MarkLoadBalancerReady(
 					[]v1alpha1.LoadBalancerIngressStatus{{
 						DomainInternal: publicSvc,
+						IP:             publicSvcIP,
 					}},
 					[]v1alpha1.LoadBalancerIngressStatus{{
 						DomainInternal: privateSvc,
+						IP:             privateSvcIP,
 					}})
 			}),
 		}},
@@ -160,9 +162,11 @@ func TestReconcile(t *testing.T) {
 				i.Status.MarkLoadBalancerReady(
 					[]v1alpha1.LoadBalancerIngressStatus{{
 						DomainInternal: publicSvc,
+						IP:             publicSvcIP,
 					}},
 					[]v1alpha1.LoadBalancerIngressStatus{{
 						DomainInternal: privateSvc,
+						IP:             privateSvcIP,
 					}})
 			}),
 		}},
@@ -283,9 +287,11 @@ func TestReconcile(t *testing.T) {
 				i.Status.MarkLoadBalancerReady(
 					[]v1alpha1.LoadBalancerIngressStatus{{
 						DomainInternal: publicSvc,
+						IP:             publicSvcIP,
 					}},
 					[]v1alpha1.LoadBalancerIngressStatus{{
 						DomainInternal: privateSvc,
+						IP:             privateSvcIP,
 					}})
 				// The rest would likely have carried over from the previous reconcile,
 				// but omitting it from the input object is less verbose.  The salient
@@ -309,9 +315,11 @@ func TestReconcile(t *testing.T) {
 				i.Status.MarkLoadBalancerReady(
 					[]v1alpha1.LoadBalancerIngressStatus{{
 						DomainInternal: publicSvc,
+						IP:             publicSvcIP,
 					}},
 					[]v1alpha1.LoadBalancerIngressStatus{{
 						DomainInternal: privateSvc,
+						IP:             privateSvcIP,
 					}})
 			}),
 		}},
@@ -424,9 +432,11 @@ func TestReconcile(t *testing.T) {
 				i.Status.MarkLoadBalancerReady(
 					[]v1alpha1.LoadBalancerIngressStatus{{
 						DomainInternal: publicSvc,
+						IP:             publicSvcIP,
 					}},
 					[]v1alpha1.LoadBalancerIngressStatus{{
 						DomainInternal: privateSvc,
+						IP:             privateSvcIP,
 					}})
 			}),
 		}},
@@ -585,10 +595,12 @@ var (
 	publicName    = "envoy-stuff"
 	publicKey     = fmt.Sprintf("%s/%s", publicNS, publicName)
 	publicSvc     = network.GetServiceHostname(publicName, publicNS)
+	publicSvcIP   = "1.2.3.4"
 	privateNS     = "crouching-cont0ur"
 	privateName   = "hidden-envoy"
 	privateKey    = fmt.Sprintf("%s/%s", privateNS, privateName)
 	privateSvc    = network.GetServiceHostname(privateName, privateNS)
+	privateSvcIP  = "5.6.7.8"
 	defaultConfig = &config.Config{
 		Contour: &config.Contour{
 			VisibilityKeys: map[v1alpha1.IngressVisibility]sets.String{
@@ -621,6 +633,25 @@ var (
 				Ports: []corev1.ServicePort{{
 					Name: "http2",
 				}},
+			},
+		},
+		// Contour Control Plane Services
+		&corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      publicName,
+				Namespace: publicNS,
+			},
+			Spec: corev1.ServiceSpec{
+				ClusterIP: publicSvcIP,
+			},
+		},
+		&corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      privateName,
+				Namespace: privateNS,
+			},
+			Spec: corev1.ServiceSpec{
+				ClusterIP: privateSvcIP,
 			},
 		},
 	}
@@ -708,9 +739,11 @@ func makeItReady(i *v1alpha1.Ingress) {
 	i.Status.MarkLoadBalancerReady(
 		[]v1alpha1.LoadBalancerIngressStatus{{
 			DomainInternal: publicSvc,
+			IP:             publicSvcIP,
 		}},
 		[]v1alpha1.LoadBalancerIngressStatus{{
 			DomainInternal: privateSvc,
+			IP:             privateSvcIP,
 		}})
 }
 

--- a/test/conformance/headless_rewrite_test.go
+++ b/test/conformance/headless_rewrite_test.go
@@ -1,0 +1,188 @@
+//go:build e2e
+// +build e2e
+
+/*
+Copyright 2021 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package conformance
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ktypes "k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"knative.dev/networking/pkg/apis/networking"
+	"knative.dev/networking/pkg/apis/networking/v1alpha1"
+	"knative.dev/networking/test"
+	"knative.dev/networking/test/conformance/ingress"
+	"knative.dev/pkg/reconciler"
+)
+
+func TestRewriteHost_HeadlessService(t *testing.T) {
+	t.Parallel()
+	ctx, clients := context.Background(), test.Setup(t)
+
+	name, port, _ := ingress.CreateRuntimeService(ctx, t, clients, networking.ServicePortNameHTTP1)
+
+	privateServiceName := test.ObjectNameForTest(t)
+	privateHostName := privateServiceName + "." + test.ServingNamespace + ".svc." + test.NetworkingFlags.ClusterSuffix
+
+	// Create a simple Ingress over the Service.
+	ing, _, _ := ingress.CreateIngressReady(ctx, t, clients, v1alpha1.IngressSpec{
+		Rules: []v1alpha1.IngressRule{{
+			Visibility: v1alpha1.IngressVisibilityClusterLocal,
+			Hosts:      []string{privateHostName},
+			HTTP: &v1alpha1.HTTPIngressRuleValue{
+				Paths: []v1alpha1.HTTPIngressPath{{
+					Splits: []v1alpha1.IngressBackendSplit{{
+						IngressBackend: v1alpha1.IngressBackend{
+							ServiceName:      name,
+							ServiceNamespace: test.ServingNamespace,
+							ServicePort:      intstr.FromInt(port),
+						},
+					}},
+				}},
+			},
+		}},
+	})
+
+	// Slap an ExternalName service in front of the kingress
+	ip := ing.Status.PrivateLoadBalancer.Ingress[0].IP
+	createHeadlessService(ctx, t, clients, privateHostName, ip)
+
+	hosts := []string{
+		"vanity.ismy.name",
+		"vanity.isalsomy.number",
+	}
+
+	// Using fixed hostnames can lead to conflicts when -count=N>1
+	// so pseudo-randomize the hostnames to avoid conflicts.
+	for i, host := range hosts {
+		hosts[i] = name + "." + host
+	}
+
+	// Now create a RewriteHost ingress to point a custom Host at the Service
+	_, client, _ := ingress.CreateIngressReady(ctx, t, clients, v1alpha1.IngressSpec{
+		Rules: []v1alpha1.IngressRule{{
+			Hosts:      hosts,
+			Visibility: v1alpha1.IngressVisibilityExternalIP,
+			HTTP: &v1alpha1.HTTPIngressRuleValue{
+				Paths: []v1alpha1.HTTPIngressPath{{
+					RewriteHost: privateHostName,
+					Splits: []v1alpha1.IngressBackendSplit{{
+						IngressBackend: v1alpha1.IngressBackend{
+							ServiceName:      privateServiceName,
+							ServiceNamespace: test.ServingNamespace,
+							ServicePort:      intstr.FromInt(80),
+						},
+					}},
+				}},
+			},
+		}},
+	})
+
+	for _, host := range hosts {
+		ingress.RuntimeRequest(ctx, t, client, "http://"+host)
+	}
+}
+
+func createHeadlessService(ctx context.Context, t *testing.T, clients *test.Clients, target, ip string) {
+	t.Helper()
+
+	targetName := strings.SplitN(target, ".", 3)
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      targetName[0],
+			Namespace: targetName[1],
+		},
+		Spec: corev1.ServiceSpec{
+			Type:            corev1.ServiceTypeClusterIP,
+			SessionAffinity: corev1.ServiceAffinityNone,
+			Ports: []corev1.ServicePort{{
+				Name:       networking.ServicePortNameH2C,
+				Port:       int32(80),
+				TargetPort: intstr.FromInt(80),
+			}},
+		},
+	}
+
+	ep := &corev1.Endpoints{
+		Subsets: []corev1.EndpointSubset{{
+			Addresses: []corev1.EndpointAddress{{
+				IP: ip,
+			}},
+			Ports: []corev1.EndpointPort{{
+				Name: networking.ServicePortNameH2C,
+				Port: 80,
+			}},
+		}},
+	}
+	ep.ObjectMeta = svc.ObjectMeta
+
+	createService(ctx, t, clients, svc)
+	createEndpoints(ctx, t, clients, ep)
+}
+
+func createEndpoints(ctx context.Context, t *testing.T, clients *test.Clients, ep *corev1.Endpoints) {
+	t.Helper()
+
+	epName := ktypes.NamespacedName{Name: ep.Name, Namespace: ep.Namespace}
+
+	if err := reconciler.RetryTestErrors(func(attempts int) error {
+		if attempts > 0 {
+			t.Logf("Attempt %d creating endpoint %s", attempts, epName)
+		}
+		_, err := clients.KubeClient.CoreV1().Endpoints(ep.Namespace).Create(ctx, ep, metav1.CreateOptions{})
+		if err != nil {
+			t.Logf("Attempt %d creating endpoint failed with: %v", attempts, err)
+		}
+		return err
+	}); err != nil {
+		t.Fatalf("Error creating endpoint %q: %v", epName, err)
+	}
+
+	t.Cleanup(func() {
+		clients.KubeClient.CoreV1().Endpoints(ep.Namespace).Delete(ctx, ep.Name, metav1.DeleteOptions{})
+	})
+}
+
+func createService(ctx context.Context, t *testing.T, clients *test.Clients, svc *corev1.Service) {
+	t.Helper()
+
+	svcName := ktypes.NamespacedName{Name: svc.Name, Namespace: svc.Namespace}
+
+	if err := reconciler.RetryTestErrors(func(attempts int) error {
+		if attempts > 0 {
+			t.Logf("Attempt %d creating service %s", attempts, svcName)
+		}
+		_, err := clients.KubeClient.CoreV1().Services(svc.Namespace).Create(ctx, svc, metav1.CreateOptions{})
+		if err != nil {
+			t.Logf("Attempt %d creating service failed with: %v", attempts, err)
+		}
+		return err
+	}); err != nil {
+		t.Fatalf("Error creating Service %q: %v", svcName, err)
+	}
+
+	t.Cleanup(func() {
+		clients.KubeClient.CoreV1().Services(svc.Namespace).Delete(ctx, svc.Name, metav1.DeleteOptions{})
+	})
+
+}

--- a/test/conformance/headless_rewrite_test.go
+++ b/test/conformance/headless_rewrite_test.go
@@ -147,7 +147,7 @@ func createEndpoints(ctx context.Context, t *testing.T, clients *test.Clients, e
 
 	if err := reconciler.RetryTestErrors(func(attempts int) error {
 		if attempts > 0 {
-			t.Logf("Attempt %d creating endpoint %s", attempts, epName)
+			t.Logf("Attempt %d creating endpoint %q", attempts, epName)
 		}
 		_, err := clients.KubeClient.CoreV1().Endpoints(ep.Namespace).Create(ctx, ep, metav1.CreateOptions{})
 		if err != nil {
@@ -170,7 +170,7 @@ func createService(ctx context.Context, t *testing.T, clients *test.Clients, svc
 
 	if err := reconciler.RetryTestErrors(func(attempts int) error {
 		if attempts > 0 {
-			t.Logf("Attempt %d creating service %s", attempts, svcName)
+			t.Logf("Attempt %d creating service %q", attempts, svcName)
 		}
 		_, err := clients.KubeClient.CoreV1().Services(svc.Namespace).Create(ctx, svc, metav1.CreateOptions{})
 		if err != nil {

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -23,6 +23,7 @@ initialize $@  --skip-istio-addon
 go_test_e2e -timeout=60m \
 	    ./test/conformance \
 	    --enable-beta --enable-alpha \
+	    --skip-tests host-rewrite \
 	    --ingressClass=contour.ingress.networking.knative.dev || fail_test
 
 success


### PR DESCRIPTION
 ExternalName support is turned off by default in Contour given the advisory:
 https://github.com/projectcontour/contour/security/advisories/GHSA-5ph6-qq5x-7jwc

The tl;dr use of ExternalName can expose sensitive services. Disabling this breaks DomainMapping
in Serving. As a workaround if a KIngress returns an LB IP Serving will manage this
endpoint using a headless service.

Part of https://github.com/knative/serving/issues/11821