### PR TITLE
WIP: Use GKE 1.20 for CI

### DIFF
--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -18,7 +18,7 @@ source $(dirname $0)/e2e-common.sh
 
 
 # Script entry point.
-initialize $@  --skip-istio-addon
+initialize $@  --skip-istio-addon --cluster-version=1.20
 
 go_test_e2e -timeout=60m \
 	    ./test/conformance \


### PR DESCRIPTION
Current CI is very unstable as https://github.com/knative/serving/issues/12091.
This patch changes to use GKE 1.20 to un-block PRs.