### PR TITLE
Add k8s recommended labels

### DIFF
--- a/config/200-clusterrole.yaml
+++ b/config/200-clusterrole.yaml
@@ -6,6 +6,9 @@ metadata:
   name: knative-serving-contour
   labels:
     networking.knative.dev/ingress-provider: contour
+    app.kubernetes.io/component: net-contour
+    app.kubernetes.io/name: knative-serving
+    app.kubernetes.io/version: devel
     serving.knative.dev/controller: "true"
 rules:
   - apiGroups: ["projectcontour.io"]

--- a/config/config-contour.yaml
+++ b/config/config-contour.yaml
@@ -19,6 +19,9 @@ metadata:
   namespace: knative-serving
   labels:
     networking.knative.dev/ingress-provider: contour
+    app.kubernetes.io/name: contour
+    app.kubernetes.io/part-of: knative-serving
+    app.kubernetes.io/version: devel
     serving.knative.dev/release: devel
 data:
   _example: |

--- a/config/config-contour.yaml
+++ b/config/config-contour.yaml
@@ -19,8 +19,8 @@ metadata:
   namespace: knative-serving
   labels:
     networking.knative.dev/ingress-provider: contour
-    app.kubernetes.io/name: contour
-    app.kubernetes.io/part-of: knative-serving
+    app.kubernetes.io/component: net-contour
+    app.kubernetes.io/name: knative-serving
     app.kubernetes.io/version: devel
     serving.knative.dev/release: devel
 data:

--- a/config/controller.yaml
+++ b/config/controller.yaml
@@ -28,6 +28,9 @@ spec:
     metadata:
       labels:
         app: net-contour-controller
+        app.kubernetes.io/component: net-contour
+        app.kubernetes.io/name: knative-serving
+        app.kubernetes.io/version: devel
     spec:
       serviceAccountName: controller
       containers:

--- a/hack/release.sh
+++ b/hack/release.sh
@@ -36,8 +36,8 @@ readonly RELEASES
 function build_release() {
   # Update release labels if this is a tagged release
   if [[ -n "${TAG}" ]]; then
-    echo "Tagged release, updating release labels to serving.knative.dev/release: \"${TAG}\""
-    LABEL_YAML_CMD=(sed -e "s|serving.knative.dev/release: devel|serving.knative.dev/release: \"${TAG}\"|")
+    echo "Tagged release, updating release labels to serving.knative.dev/release: \"${TAG}\" and app.kubernetes.io/version: \"${TAG}\""
+    LABEL_YAML_CMD=(sed -e "s|serving.knative.dev/release: devel|serving.knative.dev/release: \"${TAG}\"|" -e "s|app.kubernetes.io/version: devel|app.kubernetes.io/version: \"${TAG:1}\"|")
   else
     echo "Untagged release, will NOT update release labels"
     LABEL_YAML_CMD=(cat)

--- a/test/config/200-service-account.yaml
+++ b/test/config/200-service-account.yaml
@@ -18,8 +18,8 @@ metadata:
   name: controller
   namespace: knative-serving
   labels:
-    app.kubernetes.io/name: contour
-    app.kubernetes.io/part-of: knative-serving
+    app.kubernetes.io/component: net-contour
+    app.kubernetes.io/name: knative-serving
     app.kubernetes.io/version: devel
     serving.knative.dev/release: devel
 ---
@@ -40,8 +40,8 @@ kind: ClusterRoleBinding
 metadata:
   name: knative-serving-controller-admin
   labels:
-    app.kubernetes.io/name: contour
-    app.kubernetes.io/part-of: knative-serving
+    app.kubernetes.io/component: net-contour
+    app.kubernetes.io/name: knative-serving
     app.kubernetes.io/version: devel
     serving.knative.dev/release: devel
 subjects:

--- a/test/config/200-service-account.yaml
+++ b/test/config/200-service-account.yaml
@@ -18,6 +18,9 @@ metadata:
   name: controller
   namespace: knative-serving
   labels:
+    app.kubernetes.io/name: contour
+    app.kubernetes.io/part-of: knative-serving
+    app.kubernetes.io/version: devel
     serving.knative.dev/release: devel
 ---
 kind: ClusterRole
@@ -37,6 +40,9 @@ kind: ClusterRoleBinding
 metadata:
   name: knative-serving-controller-admin
   labels:
+    app.kubernetes.io/name: contour
+    app.kubernetes.io/part-of: knative-serving
+    app.kubernetes.io/version: devel
     serving.knative.dev/release: devel
 subjects:
   - kind: ServiceAccount

--- a/test/config/chaosduck.yaml
+++ b/test/config/chaosduck.yaml
@@ -18,9 +18,6 @@ metadata:
   name: chaosduck
   namespace: knative-serving
   labels:
-    app.kubernetes.io/name: chaosduck
-    app.kubernetes.io/part-of: knative-serving
-    app.kubernetes.io/version: devel
     serving.knative.dev/release: devel
 
 ---
@@ -30,9 +27,6 @@ metadata:
   name: chaosduck
   namespace: knative-serving
   labels:
-    app.kubernetes.io/name: chaosduck
-    app.kubernetes.io/part-of: knative-serving
-    app.kubernetes.io/version: devel
     serving.knative.dev/release: devel
 rules:
   - apiGroups: [""]
@@ -49,9 +43,6 @@ metadata:
   name: chaosduck
   namespace: knative-serving
   labels:
-    app.kubernetes.io/name: chaosduck
-    app.kubernetes.io/part-of: knative-serving
-    app.kubernetes.io/version: devel
     serving.knative.dev/release: devel
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -69,9 +60,6 @@ metadata:
   name: chaosduck
   namespace: knative-serving
   labels:
-    app.kubernetes.io/name: chaosduck
-    app.kubernetes.io/part-of: knative-serving
-    app.kubernetes.io/version: devel
     serving.knative.dev/release: devel
 spec:
   selector:

--- a/test/config/chaosduck.yaml
+++ b/test/config/chaosduck.yaml
@@ -18,6 +18,9 @@ metadata:
   name: chaosduck
   namespace: knative-serving
   labels:
+    app.kubernetes.io/name: chaosduck
+    app.kubernetes.io/part-of: knative-serving
+    app.kubernetes.io/version: devel
     serving.knative.dev/release: devel
 
 ---
@@ -27,6 +30,9 @@ metadata:
   name: chaosduck
   namespace: knative-serving
   labels:
+    app.kubernetes.io/name: chaosduck
+    app.kubernetes.io/part-of: knative-serving
+    app.kubernetes.io/version: devel
     serving.knative.dev/release: devel
 rules:
   - apiGroups: [""]
@@ -43,6 +49,9 @@ metadata:
   name: chaosduck
   namespace: knative-serving
   labels:
+    app.kubernetes.io/name: chaosduck
+    app.kubernetes.io/part-of: knative-serving
+    app.kubernetes.io/version: devel
     serving.knative.dev/release: devel
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -60,6 +69,9 @@ metadata:
   name: chaosduck
   namespace: knative-serving
   labels:
+    app.kubernetes.io/name: chaosduck
+    app.kubernetes.io/part-of: knative-serving
+    app.kubernetes.io/version: devel
     serving.knative.dev/release: devel
 spec:
   selector:


### PR DESCRIPTION
# Changes

Adds Kubernetes recommended labels to networking as discussed in https://github.com/knative/networking/issues/552

Note that changes to the labels in `vendor/knative.dev/networking` should be handled by the automation once https://github.com/knative/networking/pull/555 merges. 

/kind enhancement