### PR TITLE
[WIP][TEST ONLY]Add transport option

### DIFF
--- a/vendor/knative.dev/networking/test/test_images/httpproxy/httpproxy.go
+++ b/vendor/knative.dev/networking/test/test_images/httpproxy/httpproxy.go
@@ -98,6 +98,10 @@ func newDNSCachingTransport() http.RoundTripper {
 	resolver := &dnscache.Resolver{}
 
 	t := http.DefaultTransport.(*http.Transport).Clone()
+	t.DisableKeepAlives = false
+	t.MaxIdleConns = 1000
+	t.MaxIdleConnsPerHost = 100
+
 	t.DialContext = func(ctx context.Context, network string, addr string) (conn net.Conn, err error) {
 		host, port, err := net.SplitHostPort(addr)
 		if err != nil {


### PR DESCRIPTION
We used to have the transport option before:

https://github.com/knative/networking/blob/release-1.0/test/test_images/httpproxy/httpproxy.go#L107-L110

but it was dropped and it looks like it caused visibility test flake.
This patch tries to verify the fix.

Istio https://github.com/knative-sandbox/net-istio/pull/852 fixed the flake by this change so probably contour also does.