### PR TITLE
Copy parent HTTPOption to endpoint probe, if present.

### DIFF
--- a/pkg/reconciler/contour/resources/httpproxy.go
+++ b/pkg/reconciler/contour/resources/httpproxy.go
@@ -97,11 +97,10 @@ func MakeHTTPProxies(ctx context.Context, ing *v1alpha1.Ingress, serviceToProtoc
 	ing = ing.DeepCopy()
 	ingress.InsertProbe(ing)
 
-	hostToTLS := make(map[string]*v1alpha1.IngressTLS, len(ing.Spec.TLS))
+	hostToTLS := make(map[string]v1alpha1.IngressTLS, len(ing.Spec.TLS))
 	for _, tls := range ing.Spec.TLS {
 		for _, host := range tls.Hosts {
-			t := tls
-			hostToTLS[host] = &t
+			hostToTLS[host] = tls
 		}
 	}
 

--- a/pkg/reconciler/contour/resources/kingress.go
+++ b/pkg/reconciler/contour/resources/kingress.go
@@ -47,10 +47,12 @@ func MakeEndpointProbeIngress(ctx context.Context, ing *v1alpha1.Ingress, previo
 			OwnerReferences: []metav1.OwnerReference{*kmeta.NewControllerRef(ing)},
 		},
 		Spec: v1alpha1.IngressSpec{
-			// TODO: Probing against HTTP should be enough as it ensures Envoy's EDS?
-			// Need to verify it by scale-N test with HTTPS.
-			HTTPOption: v1alpha1.HTTPOptionEnabled,
+			HTTPOption: ing.Spec.HTTPOption,
 		},
+	}
+
+	if childIng.Spec.HTTPOption == "" {
+		childIng.Spec.HTTPOption = v1alpha1.HTTPOptionEnabled
 	}
 
 	sns := ServiceNames(ctx, ing)

--- a/pkg/reconciler/contour/resources/kingress_test.go
+++ b/pkg/reconciler/contour/resources/kingress_test.go
@@ -286,6 +286,10 @@ func TestMakeEndpointProbeIngress(t *testing.T) {
 						}},
 					},
 				}},
+				TLS: []v1alpha1.IngressTLS{{
+					Hosts:      []string{"example.com"},
+					SecretName: "example",
+				}},
 			},
 		},
 		want: &v1alpha1.Ingress{
@@ -319,6 +323,10 @@ func TestMakeEndpointProbeIngress(t *testing.T) {
 							}},
 						}},
 					},
+				}},
+				TLS: []v1alpha1.IngressTLS{{
+					Hosts:      []string{"example.com"},
+					SecretName: "example",
 				}},
 			},
 		},

--- a/pkg/reconciler/contour/resources/kingress_test.go
+++ b/pkg/reconciler/contour/resources/kingress_test.go
@@ -264,6 +264,65 @@ func TestMakeEndpointProbeIngress(t *testing.T) {
 			},
 		},
 	}, {
+		name: "https-only",
+		ing: &v1alpha1.Ingress{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "foo",
+				Name:      "bar",
+			},
+			Spec: v1alpha1.IngressSpec{
+				HTTPOption: v1alpha1.HTTPOptionRedirected,
+				Rules: []v1alpha1.IngressRule{{
+					Hosts: []string{"example.com"},
+					HTTP: &v1alpha1.HTTPIngressRuleValue{
+						Paths: []v1alpha1.HTTPIngressPath{{
+							Splits: []v1alpha1.IngressBackendSplit{{
+								IngressBackend: v1alpha1.IngressBackend{
+									ServiceName: "goo",
+									ServicePort: intstr.FromInt(123),
+								},
+								Percent: 100,
+							}},
+						}},
+					},
+				}},
+			},
+		},
+		want: &v1alpha1.Ingress{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "foo",
+				Name:      "bar--ep",
+				Annotations: map[string]string{
+					EndpointsProbeKey: "true",
+				},
+				OwnerReferences: []metav1.OwnerReference{{
+					APIVersion:         "networking.internal.knative.dev/v1alpha1",
+					Kind:               "Ingress",
+					Name:               "bar",
+					Controller:         ptr.Bool(true),
+					BlockOwnerDeletion: ptr.Bool(true),
+				}},
+			},
+			Spec: v1alpha1.IngressSpec{
+				HTTPOption: v1alpha1.HTTPOptionRedirected,
+				Rules: []v1alpha1.IngressRule{{
+					Hosts: []string{"goo.gen-0.bar.foo.net-contour.invalid"},
+					HTTP: &v1alpha1.HTTPIngressRuleValue{
+						Paths: []v1alpha1.HTTPIngressPath{{
+							Splits: []v1alpha1.IngressBackendSplit{{
+								IngressBackend: v1alpha1.IngressBackend{
+									ServiceNamespace: "foo",
+									ServiceName:      "goo",
+									ServicePort:      intstr.FromInt(123),
+								},
+								Percent: 100,
+							}},
+						}},
+					},
+				}},
+			},
+		},
+	}, {
 		name: "multiple paths with header conditions",
 		ing: &v1alpha1.Ingress{
 			ObjectMeta: metav1.ObjectMeta{

--- a/pkg/reconciler/contour/resources/kingress_test.go
+++ b/pkg/reconciler/contour/resources/kingress_test.go
@@ -325,7 +325,7 @@ func TestMakeEndpointProbeIngress(t *testing.T) {
 					},
 				}},
 				TLS: []v1alpha1.IngressTLS{{
-					Hosts:      []string{"example.com"},
+					Hosts:      []string{"goo.gen-0.bar.foo.net-contour.invalid"},
 					SecretName: "example",
 				}},
 			},


### PR DESCRIPTION
Fixes #712
