### PR TITLE
Add nightly build to run e2e tests against Contour main

### DIFF
--- a/.github/workflows/kind-e2e-nightly.yaml
+++ b/.github/workflows/kind-e2e-nightly.yaml
@@ -1,0 +1,206 @@
+name: KinD e2e nightly tests
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+
+defaults:
+  run:
+    shell: bash
+    working-directory: ./src/knative.dev/net-contour
+
+jobs:
+  e2e-tests:
+    name: e2e tests
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false # Keep running if one leg fails.
+      matrix:
+        k8s-version:
+        - v1.21.1
+        - v1.22.0
+        - v1.23.0
+
+        test-suite:
+        - ./test/conformance
+
+        # Map between K8s and KinD versions.
+        # This is attempting to make it a bit clearer what's being tested.
+        # See: https://github.com/kubernetes-sigs/kind/releases
+        include:
+        - k8s-version: v1.21.1
+          kind-version: v0.11.1
+          kind-image-sha: sha256:69860bda5563ac81e3c0057d654b5253219618a22ec3a346306239bba8cfa1a6
+          install: yaml
+        - k8s-version: v1.22.0
+          kind-version: v0.11.1
+          kind-image-sha: sha256:f97edf7f7ed53c57762b24f90a34fad101386c5bd4d93baeb45449557148c717
+          install: yaml
+        - k8s-version: v1.23.0
+          kind-version: v0.11.1
+          kind-image-sha: sha256:49824ab1727c04e56a21a5d8372a402fcd32ea51ac96a2706a12af38934f81ac
+          install: yaml
+
+    env:
+      GOPATH: ${{ github.workspace }}
+      KO_DOCKER_REPO: kind.local
+      # Use a semi-random cluster suffix, but somewhat predictable
+      # so reruns don't just give us a completely new value.
+      CLUSTER_SUFFIX: c${{ github.run_id }}.local
+
+    steps:
+    - name: Set up Go 1.17.x
+      uses: actions/setup-go@v2
+      with:
+        go-version: 1.17.x
+
+    - name: Install Dependencies
+      working-directory: ./
+      run: |
+        echo '::group:: install ko'
+        curl -L https://github.com/google/ko/releases/download/v0.9.3/ko_0.9.3_Linux_x86_64.tar.gz | tar xzf - ko
+        chmod +x ./ko
+        sudo mv ko /usr/local/bin
+        echo '::endgroup::'
+
+    - name: Check out code onto GOPATH
+      uses: actions/checkout@v2
+      with:
+        path: ./src/knative.dev/net-contour
+
+    - name: Install KinD
+      run: |
+        set -x
+
+        # Disable swap otherwise memory enforcement doesn't work
+        # See: https://kubernetes.slack.com/archives/CEKK1KTN2/p1600009955324200
+        sudo swapoff -a
+        sudo rm -f /swapfile
+
+        # Use in-memory storage to avoid etcd server timeouts.
+        # https://kubernetes.slack.com/archives/CEKK1KTN2/p1615134111016300
+        # https://github.com/kubernetes-sigs/kind/issues/845
+        #
+        sudo mkdir -p /tmp/etcd
+        sudo mount -t tmpfs tmpfs /tmp/etcd
+
+        curl -Lo ./kind https://github.com/kubernetes-sigs/kind/releases/download/${{ matrix.kind-version }}/kind-$(uname)-amd64
+        chmod +x ./kind
+        sudo mv kind /usr/local/bin
+
+    - name: Create KinD Cluster
+      run: |
+        set -x
+
+        # KinD configuration.
+        cat > kind.yaml <<EOF
+        apiVersion: kind.x-k8s.io/v1alpha4
+        kind: Cluster
+        nodes:
+        - role: control-plane
+          image: kindest/node:${{ matrix.k8s-version }}@${{ matrix.kind-image-sha }}
+          extraMounts:
+          - containerPath: /var/lib/etcd
+            hostPath: /tmp/etcd
+        - role: worker
+          image: kindest/node:${{ matrix.k8s-version }}@${{ matrix.kind-image-sha }}
+
+        # This is needed in order to
+        # (1) support projected volumes with service account tokens. See
+        #     https://kubernetes.slack.com/archives/CEKK1KTN2/p1600268272383600
+        # (2) use a random cluster suffix
+        kubeadmConfigPatches:
+          - |
+            apiVersion: kubeadm.k8s.io/v1beta2
+            kind: ClusterConfiguration
+            metadata:
+              name: config
+            apiServer:
+              extraArgs:
+                "service-account-issuer": "kubernetes.default.svc"
+                "service-account-signing-key-file": "/etc/kubernetes/pki/sa.key"
+            networking:
+              dnsDomain: "${CLUSTER_SUFFIX}"
+        EOF
+
+        # Create a cluster!
+        kind create cluster --config kind.yaml
+
+    - name: Setup metallb
+      run: |
+        kubectl apply -f https://raw.githubusercontent.com/metallb/metallb/v0.9.3/manifests/namespace.yaml
+        kubectl apply -f https://raw.githubusercontent.com/metallb/metallb/v0.9.3/manifests/metallb.yaml
+        kubectl create secret generic -n metallb-system memberlist --from-literal=secretkey="$(openssl rand -base64 128)"
+
+        network=$(docker network inspect kind -f "{{(index .IPAM.Config 0).Subnet}}" | cut -d '.' -f1,2)
+        cat <<EOF | kubectl apply -f -
+        apiVersion: v1
+        kind: ConfigMap
+        metadata:
+          namespace: metallb-system
+          name: config
+        data:
+          config: |
+            address-pools:
+            - name: default
+              protocol: layer2
+              addresses:
+              - $network.255.1-$network.255.250
+        EOF
+
+    - name: Install Knative net-contour (non operator)
+      if: matrix.install == 'yaml'
+      run: |
+        set -o pipefail
+
+        wget -O /tmp/contour-main.yaml https://projectcontour.io/quickstart/main/contour.yaml
+        envoy_image="$(grep 'docker.io/envoyproxy/envoy' /tmp/contour-main.yaml | awk '{ print $2 }' | sed 's/\//\\\//g')"
+
+        # Build and Publish our containers to the docker daemon (including test assets)
+        ko resolve --platform=linux/amd64 -Pf test/config/ -f config/contour -f config | \
+          sed 's/imagePullPolicy:/# DISABLED: imagePullPolicy:/g' | \
+          sed 's/image: ghcr.io\/projectcontour\/contour:.*/image: ghcr.io\/projectcontour\/contour:main/g' | \
+          sed "s/image: docker.io\/envoyproxy\/envoy:.*/image: ${envoy_image}/g" | \
+          kubectl apply -f -
+
+    - name: Upload Test Images
+      run: |
+        # Build and Publish our test images to the docker daemon.
+        ./test/upload-test-images.sh
+
+    - name: Wait for Ready
+      run: |
+        echo Waiting for Pods to become ready.
+        kubectl wait pod --for=condition=Ready -n contour-external -l '!job-name'
+        kubectl wait pod --for=condition=Ready -n contour-internal -l '!job-name'
+        # # TODO(mattmoor): Find a good way to do this with chaos enabled.
+        # kubectl wait pod --for=condition=Ready -n knative-serving  --all
+
+        # For debugging.
+        kubectl get pods --all-namespaces
+
+    - name: Run e2e Tests
+      run: |
+        set -x
+
+        # Run the tests tagged as e2e on the KinD cluster.
+        go test -race -count=1 -short -timeout=20m -tags=e2e ${{ matrix.test-suite }} \
+           --enable-beta --enable-alpha \
+           --skip-tests host-rewrite \
+           --ingressClass=contour.ingress.networking.knative.dev \
+           --cluster-suffix=$CLUSTER_SUFFIX
+
+    - name: Post failure notice to Slack
+      uses: rtCamp/action-slack-notify@v2.1.0
+      if: ${{ failure() && github.event_name != 'pull_request' }}
+      env:
+        SLACK_ICON: http://github.com/knative.png?size=48
+        SLACK_USERNAME: github-actions
+        SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+
+        SLACK_CHANNEL: 'net-contour'
+        SLACK_COLOR: '#8E1600'
+        MSG_MINIMAL: 'true'
+        SLACK_TITLE: Periodic ${{ matrix.k8s-version }} failed.
+        SLACK_MESSAGE: |
+          For detailed logs: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}


### PR DESCRIPTION
# Changes

- Swaps out versioned Contour image for main image
- Swaps out Envoy image for image in main example manifest
- For now omits Contour Operator version of build
- See https://github.com/projectcontour/contour/issues/2863

/kind cleanup

(no category for CI/testing/etc. so can update if needed ^)


**Release Note**

N/A

**Docs**

N/A
