### PR TITLE
Rename certgen job in nightly build CI

### DIFF
--- a/.github/workflows/kind-e2e-nightly.yaml
+++ b/.github/workflows/kind-e2e-nightly.yaml
@@ -160,6 +160,7 @@ jobs:
         ko resolve --platform=linux/amd64 -Pf test/config/ -f config/contour -f config | \
           sed 's/imagePullPolicy:/# DISABLED: imagePullPolicy:/g' | \
           sed 's/image: ghcr.io\/projectcontour\/contour:.*/image: ghcr.io\/projectcontour\/contour:main/g' | \
+          sed 's/name: contour-certgen-.*/name: contour-certgen-main/g' | \
           sed "s/image: docker.io\/envoyproxy\/envoy:.*/image: ${envoy_image}/g" | \
           kubectl apply -f -
 


### PR DESCRIPTION
# Changes

Rename certgen job in nightly build CI from `contour-certgen-<version>` to `contour-certgen-main`

To ensure there is no confusion when debugging this job

/kind cleanup

**Release Note**

N/A

**Docs**

N/A