### PR TITLE
Bump k8s version in KinD

### DIFF
--- a/.github/workflows/kind-e2e-nightly.yaml
+++ b/.github/workflows/kind-e2e-nightly.yaml
@@ -17,9 +17,8 @@ jobs:
       fail-fast: false # Keep running if one leg fails.
       matrix:
         k8s-version:
-        - v1.21.1
-        - v1.22.0
-        - v1.23.0
+        - v1.22.7
+        - v1.23.5
 
         test-suite:
         - ./test/conformance
@@ -28,17 +27,14 @@ jobs:
         # This is attempting to make it a bit clearer what's being tested.
         # See: https://github.com/kubernetes-sigs/kind/releases
         include:
-        - k8s-version: v1.21.1
-          kind-version: v0.11.1
-          kind-image-sha: sha256:69860bda5563ac81e3c0057d654b5253219618a22ec3a346306239bba8cfa1a6
+        - k8s-version: v1.22.7
+          kind-version: v0.12.0
+          kind-image-sha: sha256:1dfd72d193bf7da64765fd2f2898f78663b9ba366c2aa74be1fd7498a1873166
           install: yaml
-        - k8s-version: v1.22.0
-          kind-version: v0.11.1
-          kind-image-sha: sha256:f97edf7f7ed53c57762b24f90a34fad101386c5bd4d93baeb45449557148c717
-          install: yaml
-        - k8s-version: v1.23.0
-          kind-version: v0.11.1
-          kind-image-sha: sha256:49824ab1727c04e56a21a5d8372a402fcd32ea51ac96a2706a12af38934f81ac
+
+        - k8s-version: v1.23.5
+          kind-version: v0.12.0
+          kind-image-sha: sha256:a69c29d3d502635369a5fe92d8e503c09581fcd406ba6598acc5d80ff5ba81b1
           install: yaml
 
     env:

--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -36,7 +36,7 @@ jobs:
           install: yaml
 
         - k8s-version: v1.23.5
-          kind-version: v0.12.0
+          kind-version: v0.11.1
           kind-image-sha: sha256:a69c29d3d502635369a5fe92d8e503c09581fcd406ba6598acc5d80ff5ba81b1
           install: yaml
 

--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -20,9 +20,8 @@ jobs:
       fail-fast: false # Keep running if one leg fails.
       matrix:
         k8s-version:
-        - v1.21.1
-        - v1.22.0
-        - v1.23.0
+        - v1.22.7
+        - v1.23.5
 
         test-suite:
         - ./test/conformance
@@ -31,17 +30,14 @@ jobs:
         # This is attempting to make it a bit clearer what's being tested.
         # See: https://github.com/kubernetes-sigs/kind/releases
         include:
-        - k8s-version: v1.21.1
-          kind-version: v0.11.1
-          kind-image-sha: sha256:69860bda5563ac81e3c0057d654b5253219618a22ec3a346306239bba8cfa1a6
+        - k8s-version: v1.22.7
+          kind-version: v0.12.0
+          kind-image-sha: sha256:1dfd72d193bf7da64765fd2f2898f78663b9ba366c2aa74be1fd7498a1873166
           install: yaml
-        - k8s-version: v1.22.0
-          kind-version: v0.11.1
-          kind-image-sha: sha256:f97edf7f7ed53c57762b24f90a34fad101386c5bd4d93baeb45449557148c717
-          install: yaml
-        - k8s-version: v1.23.0
-          kind-version: v0.11.1
-          kind-image-sha: sha256:49824ab1727c04e56a21a5d8372a402fcd32ea51ac96a2706a12af38934f81ac
+
+        - k8s-version: v1.23.5
+          kind-version: v0.12.0
+          kind-image-sha: sha256:a69c29d3d502635369a5fe92d8e503c09581fcd406ba6598acc5d80ff5ba81b1
           install: yaml
 
     env:


### PR DESCRIPTION
As per title, this patch bumps k8s version in KinD.

1.21 is no longer supported and auto upgrade keeps failing as https://github.com/knative-sandbox/net-contour/pull/749.