### PR TITLE
Internal Encryption fixes

### DIFF
--- a/pkg/reconciler/contour/resources/constants.go
+++ b/pkg/reconciler/contour/resources/constants.go
@@ -45,6 +45,10 @@ const (
 	//Contour's Envoys to encrypt the traffic to the activator.
 	InternalEncryptionProtocol   = "tls"
 	InternalEncryptionH2Protocol = "h2"
+
+	//HttpChallengePath is the path that gets added to routes when using
+	//auto-TLS with an http01 solver as the issuer.
+	HTTPChallengePath = "/.well-known/acme-challenge"
 )
 
 // These are the annotations which are optionally set in ksvc/ingress

--- a/pkg/reconciler/contour/resources/httpproxy.go
+++ b/pkg/reconciler/contour/resources/httpproxy.go
@@ -32,6 +32,7 @@ import (
 	"knative.dev/net-contour/pkg/reconciler/contour/config"
 	"knative.dev/networking/pkg/apis/networking/v1alpha1"
 	netcfg "knative.dev/networking/pkg/config"
+	netheader "knative.dev/networking/pkg/http/header"
 	"knative.dev/networking/pkg/ingress"
 	"knative.dev/pkg/kmeta"
 	"knative.dev/pkg/network"
@@ -170,11 +171,16 @@ func MakeHTTPProxies(ctx context.Context, ing *v1alpha1.Ingress, serviceToProtoc
 				postSplitHeaders := &v1.HeadersPolicy{
 					Set: make([]v1.HeaderValue, 0, len(split.AppendHeaders)),
 				}
+
+				hasOriginalHostKey := false
 				for key, value := range split.AppendHeaders {
 					postSplitHeaders.Set = append(postSplitHeaders.Set, v1.HeaderValue{
 						Name:  key,
 						Value: value,
 					})
+					if key == netheader.OriginalHostKey {
+						hasOriginalHostKey = true
+					}
 				}
 				if len(postSplitHeaders.Set) > 0 {
 					sort.Slice(postSplitHeaders.Set, func(i, j int) bool {
@@ -187,7 +193,18 @@ func MakeHTTPProxies(ctx context.Context, ing *v1alpha1.Ingress, serviceToProtoc
 				svc.RequestHeadersPolicy = postSplitHeaders
 
 				if proto, ok := serviceToProtocol[split.ServiceName]; ok {
-					svc.Protocol = ptr.String(proto)
+					//In order for domain mappings to work with internal
+					//encryption, need to unencrypt traffic back to the envoy.
+					//See
+					//https://github.com/knative-sandbox/net-contour/issues/862
+					//Can identify domain mappings by the presence of the RewriteHost field on
+					//the Path in combination with the "K-Original-Host" key in appendHeaders on
+					//the split
+					if path.RewriteHost != "" && hasOriginalHostKey {
+						svc.Protocol = ptr.String("h2c")
+					} else {
+						svc.Protocol = ptr.String(proto)
+					}
 				}
 
 				if cfg.Network != nil && cfg.Network.InternalEncryption {

--- a/pkg/reconciler/contour/resources/httpproxy.go
+++ b/pkg/reconciler/contour/resources/httpproxy.go
@@ -214,6 +214,12 @@ func MakeHTTPProxies(ctx context.Context, ing *v1alpha1.Ingress, serviceToProtoc
 					}
 				}
 
+				if strings.Contains(path.Path, HTTPChallengePath) {
+					//make sure http01 challenge doesn't get encrypted or use http2
+					svc.Protocol = nil
+					svc.UpstreamValidation = nil
+				}
+
 				svcs = append(svcs, svc)
 			}
 

--- a/pkg/reconciler/contour/resources/httpproxy_test.go
+++ b/pkg/reconciler/contour/resources/httpproxy_test.go
@@ -2017,145 +2017,340 @@ func TestMakeProxiesInternalEncryption(t *testing.T) {
 				}},
 			},
 		}},
-	},
-		{
-			name: "single external domain with internal encryption enabled and http/2",
-			ing: &v1alpha1.Ingress{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: "foo",
-					Name:      "bar",
-				},
-				Spec: v1alpha1.IngressSpec{
-					HTTPOption: v1alpha1.HTTPOptionEnabled,
-					Rules: []v1alpha1.IngressRule{{
-						Hosts:      []string{"example.com"},
-						Visibility: v1alpha1.IngressVisibilityExternalIP,
-						HTTP: &v1alpha1.HTTPIngressRuleValue{
-							Paths: []v1alpha1.HTTPIngressPath{{
-								AppendHeaders: map[string]string{
-									"Foo": "bar",
+	}, {
+		name: "single external domain with internal encryption enabled and http/2",
+		ing: &v1alpha1.Ingress{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "foo",
+				Name:      "bar",
+			},
+			Spec: v1alpha1.IngressSpec{
+				HTTPOption: v1alpha1.HTTPOptionEnabled,
+				Rules: []v1alpha1.IngressRule{{
+					Hosts:      []string{"example.com"},
+					Visibility: v1alpha1.IngressVisibilityExternalIP,
+					HTTP: &v1alpha1.HTTPIngressRuleValue{
+						Paths: []v1alpha1.HTTPIngressPath{{
+							AppendHeaders: map[string]string{
+								"Foo": "bar",
+							},
+							Splits: []v1alpha1.IngressBackendSplit{{
+								IngressBackend: v1alpha1.IngressBackend{
+									ServiceName:      "htwo",
+									ServiceNamespace: "foo",
+									ServicePort:      intstr.FromInt(123),
 								},
-								Splits: []v1alpha1.IngressBackendSplit{{
+								Percent: 100,
+								AppendHeaders: map[string]string{
+									"Baz":   "blah",
+									"Bleep": "bloop",
+								},
+							}},
+						}},
+					},
+				}},
+			},
+		},
+		want: []*v1.HTTPProxy{{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "foo",
+				Name:      "bar-" + publicClass + "-example.com",
+				Labels: map[string]string{
+					DomainHashKey: "0caaf24ab1a0c33440c06afe99df986365b0781f",
+					GenerationKey: "0",
+					ParentKey:     "bar",
+					ClassKey:      publicClass,
+				},
+				Annotations: map[string]string{
+					ClassKey: publicClass,
+				},
+				OwnerReferences: []metav1.OwnerReference{{
+					APIVersion:         "networking.internal.knative.dev/v1alpha1",
+					Kind:               "Ingress",
+					Name:               "bar",
+					Controller:         ptr.Bool(true),
+					BlockOwnerDeletion: ptr.Bool(true),
+				}},
+			},
+			Spec: v1.HTTPProxySpec{
+				VirtualHost: &v1.VirtualHost{
+					Fqdn: "example.com",
+				},
+				Routes: []v1.Route{{
+					EnableWebsockets: true,
+					PermitInsecure:   true,
+					TimeoutPolicy: &v1.TimeoutPolicy{
+						Response: "infinity",
+						Idle:     "infinity",
+					},
+					RetryPolicy: defaultRetryPolicy(),
+					Conditions: []v1.MatchCondition{{
+						Header: &v1.HeaderMatchCondition{
+							Name:  "K-Network-Hash",
+							Exact: "override",
+						},
+					}},
+					RequestHeadersPolicy: &v1.HeadersPolicy{
+						Set: []v1.HeaderValue{{
+							Name:  "Foo",
+							Value: "bar",
+						}, {
+							Name:  "K-Network-Hash",
+							Value: "fe69d18ca560b548fd9cd1fe9a417a4de806f573b52353a435e222a23a984127",
+						}},
+					},
+					Services: []v1.Service{{
+						Name:     "htwo",
+						Port:     123,
+						Protocol: &h2Proto,
+						UpstreamValidation: &v1.UpstreamValidation{
+							CACertificate: fmt.Sprintf("%s/knative-serving-certs", system.Namespace()),
+							SubjectName:   "data-plane.knative.dev",
+						},
+						Weight: 100,
+						RequestHeadersPolicy: &v1.HeadersPolicy{
+							Set: []v1.HeaderValue{{
+								Name:  "Baz",
+								Value: "blah",
+							}, {
+								Name:  "Bleep",
+								Value: "bloop",
+							}},
+						},
+					}},
+				}, {
+					EnableWebsockets: true,
+					PermitInsecure:   true,
+					TimeoutPolicy: &v1.TimeoutPolicy{
+						Response: "infinity",
+						Idle:     "infinity",
+					},
+					RetryPolicy: defaultRetryPolicy(),
+					RequestHeadersPolicy: &v1.HeadersPolicy{
+						Set: []v1.HeaderValue{{
+							Name:  "Foo",
+							Value: "bar",
+						}},
+					},
+					Services: []v1.Service{{
+						Name:     "htwo",
+						Port:     123,
+						Protocol: &h2Proto,
+						UpstreamValidation: &v1.UpstreamValidation{
+							CACertificate: fmt.Sprintf("%s/knative-serving-certs", system.Namespace()),
+							SubjectName:   "data-plane.knative.dev",
+						},
+						Weight: 100,
+						RequestHeadersPolicy: &v1.HeadersPolicy{
+							Set: []v1.HeaderValue{{
+								Name:  "Baz",
+								Value: "blah",
+							}, {
+								Name:  "Bleep",
+								Value: "bloop",
+							}},
+						},
+					}},
+				}},
+			},
+		}},
+	}, {
+		name: "single external domain with internal encryption enabled and http01 challenge endpoints",
+		ing: &v1alpha1.Ingress{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "foo",
+				Name:      "bar",
+			},
+			Spec: v1alpha1.IngressSpec{
+				HTTPOption: v1alpha1.HTTPOptionEnabled,
+				Rules: []v1alpha1.IngressRule{{
+					Hosts:      []string{"example.com"},
+					Visibility: v1alpha1.IngressVisibilityExternalIP,
+					HTTP: &v1alpha1.HTTPIngressRuleValue{
+						Paths: []v1alpha1.HTTPIngressPath{{
+							Splits: []v1alpha1.IngressBackendSplit{{
+								IngressBackend: v1alpha1.IngressBackend{
+									ServiceName:      "goo",
+									ServiceNamespace: "foo",
+									ServicePort:      intstr.FromInt(123),
+								},
+								Percent: 100,
+								AppendHeaders: map[string]string{
+									"Baz":   "blah",
+									"Bleep": "bloop",
+								},
+							}},
+						}, {
+							Path: "/.well-known/acme-challenge/some-challenge",
+							Splits: []v1alpha1.IngressBackendSplit{
+								{
 									IngressBackend: v1alpha1.IngressBackend{
-										ServiceName:      "htwo",
+										ServiceName:      "acme-http-solver",
 										ServiceNamespace: "foo",
-										ServicePort:      intstr.FromInt(123),
+										ServicePort:      intstr.FromInt(8089),
 									},
 									Percent: 100,
-									AppendHeaders: map[string]string{
-										"Baz":   "blah",
-										"Bleep": "bloop",
-									},
-								}},
-							}},
-						},
-					}},
-				},
+								},
+							},
+							/*
+								Note for self: http01 challenges only come up for new domains. So if you delete hello and recreate it, a new challenge won't happen, and won't trigger the case where it tries to use tls to the challenge endpoint
+								   - path: /.well-known/acme-challenge/DzPfge0gXYvu417QIIQ9IAd9_YaG-rl_qby3HQlBbQA
+								     splits:
+								     - percent: 100
+								       serviceName: cm-acme-http-solver-rczvs
+								       serviceNamespace: default
+								       servicePort: 8089
+							*/
+
+						}},
+					},
+				}},
 			},
-			want: []*v1.HTTPProxy{{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: "foo",
-					Name:      "bar-" + publicClass + "-example.com",
-					Labels: map[string]string{
-						DomainHashKey: "0caaf24ab1a0c33440c06afe99df986365b0781f",
-						GenerationKey: "0",
-						ParentKey:     "bar",
-						ClassKey:      publicClass,
-					},
-					Annotations: map[string]string{
-						ClassKey: publicClass,
-					},
-					OwnerReferences: []metav1.OwnerReference{{
-						APIVersion:         "networking.internal.knative.dev/v1alpha1",
-						Kind:               "Ingress",
-						Name:               "bar",
-						Controller:         ptr.Bool(true),
-						BlockOwnerDeletion: ptr.Bool(true),
-					}},
-				},
-				Spec: v1.HTTPProxySpec{
-					VirtualHost: &v1.VirtualHost{
-						Fqdn: "example.com",
-					},
-					Routes: []v1.Route{{
-						EnableWebsockets: true,
-						PermitInsecure:   true,
-						TimeoutPolicy: &v1.TimeoutPolicy{
-							Response: "infinity",
-							Idle:     "infinity",
-						},
-						RetryPolicy: defaultRetryPolicy(),
-						Conditions: []v1.MatchCondition{{
-							Header: &v1.HeaderMatchCondition{
-								Name:  "K-Network-Hash",
-								Exact: "override",
-							},
-						}},
-						RequestHeadersPolicy: &v1.HeadersPolicy{
-							Set: []v1.HeaderValue{{
-								Name:  "Foo",
-								Value: "bar",
-							}, {
-								Name:  "K-Network-Hash",
-								Value: "fe69d18ca560b548fd9cd1fe9a417a4de806f573b52353a435e222a23a984127",
-							}},
-						},
-						Services: []v1.Service{{
-							Name:     "htwo",
-							Port:     123,
-							Protocol: &h2Proto,
-							UpstreamValidation: &v1.UpstreamValidation{
-								CACertificate: fmt.Sprintf("%s/knative-serving-certs", system.Namespace()),
-								SubjectName:   "data-plane.knative.dev",
-							},
-							Weight: 100,
-							RequestHeadersPolicy: &v1.HeadersPolicy{
-								Set: []v1.HeaderValue{{
-									Name:  "Baz",
-									Value: "blah",
-								}, {
-									Name:  "Bleep",
-									Value: "bloop",
-								}},
-							},
-						}},
-					}, {
-						EnableWebsockets: true,
-						PermitInsecure:   true,
-						TimeoutPolicy: &v1.TimeoutPolicy{
-							Response: "infinity",
-							Idle:     "infinity",
-						},
-						RetryPolicy: defaultRetryPolicy(),
-						RequestHeadersPolicy: &v1.HeadersPolicy{
-							Set: []v1.HeaderValue{{
-								Name:  "Foo",
-								Value: "bar",
-							}},
-						},
-						Services: []v1.Service{{
-							Name:     "htwo",
-							Port:     123,
-							Protocol: &h2Proto,
-							UpstreamValidation: &v1.UpstreamValidation{
-								CACertificate: fmt.Sprintf("%s/knative-serving-certs", system.Namespace()),
-								SubjectName:   "data-plane.knative.dev",
-							},
-							Weight: 100,
-							RequestHeadersPolicy: &v1.HeadersPolicy{
-								Set: []v1.HeaderValue{{
-									Name:  "Baz",
-									Value: "blah",
-								}, {
-									Name:  "Bleep",
-									Value: "bloop",
-								}},
-							},
-						}},
-					}},
-				},
-			}},
 		},
+		want: []*v1.HTTPProxy{{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "foo",
+				Name:      "bar-" + publicClass + "-example.com",
+				Labels: map[string]string{
+					DomainHashKey: "0caaf24ab1a0c33440c06afe99df986365b0781f",
+					GenerationKey: "0",
+					ParentKey:     "bar",
+					ClassKey:      publicClass,
+				},
+				Annotations: map[string]string{
+					ClassKey: publicClass,
+				},
+				OwnerReferences: []metav1.OwnerReference{{
+					APIVersion:         "networking.internal.knative.dev/v1alpha1",
+					Kind:               "Ingress",
+					Name:               "bar",
+					Controller:         ptr.Bool(true),
+					BlockOwnerDeletion: ptr.Bool(true),
+				}},
+			},
+			Spec: v1.HTTPProxySpec{
+				VirtualHost: &v1.VirtualHost{
+					Fqdn: "example.com",
+				},
+				Routes: []v1.Route{{
+					EnableWebsockets: true,
+					PermitInsecure:   true,
+					TimeoutPolicy: &v1.TimeoutPolicy{
+						Response: "infinity",
+						Idle:     "infinity",
+					},
+					RetryPolicy: defaultRetryPolicy(),
+					RequestHeadersPolicy: &v1.HeadersPolicy{
+						Set: []v1.HeaderValue{{
+							Name:  "K-Network-Hash",
+							Value: "62a84eab49a55afbf471afc85d08701d4beff2fc957b4d7614048320d0795597",
+						}},
+					},
+					Conditions: []v1.MatchCondition{{
+						Header: &v1.HeaderMatchCondition{
+							Name:  "K-Network-Hash",
+							Exact: "override",
+						},
+					}},
+					Services: []v1.Service{{
+						Name:     "goo",
+						Port:     123,
+						Protocol: &tlsProto,
+						UpstreamValidation: &v1.UpstreamValidation{
+							CACertificate: fmt.Sprintf("%s/knative-serving-certs", system.Namespace()),
+							SubjectName:   "data-plane.knative.dev",
+						},
+						Weight: 100,
+						RequestHeadersPolicy: &v1.HeadersPolicy{
+							Set: []v1.HeaderValue{{
+								Name:  "Baz",
+								Value: "blah",
+							}, {
+								Name:  "Bleep",
+								Value: "bloop",
+							}},
+						},
+					}},
+				}, {
+					EnableWebsockets: true,
+					PermitInsecure:   true,
+					TimeoutPolicy: &v1.TimeoutPolicy{
+						Response: "infinity",
+						Idle:     "infinity",
+					},
+					RetryPolicy: defaultRetryPolicy(),
+					RequestHeadersPolicy: &v1.HeadersPolicy{
+						Set: []v1.HeaderValue{{
+							Name:  "K-Network-Hash",
+							Value: "62a84eab49a55afbf471afc85d08701d4beff2fc957b4d7614048320d0795597",
+						}},
+					},
+					Conditions: []v1.MatchCondition{{
+						Prefix: "/.well-known/acme-challenge/some-challenge",
+					}, {
+						Header: &v1.HeaderMatchCondition{
+							Name:  "K-Network-Hash",
+							Exact: "override",
+						},
+					}},
+					Services: []v1.Service{{
+						Name:   "acme-http-solver",
+						Port:   8089,
+						Weight: 100,
+					}},
+				}, {
+					EnableWebsockets: true,
+					PermitInsecure:   true,
+					TimeoutPolicy: &v1.TimeoutPolicy{
+						Response: "infinity",
+						Idle:     "infinity",
+					},
+					RetryPolicy: defaultRetryPolicy(),
+					RequestHeadersPolicy: &v1.HeadersPolicy{
+						Set: []v1.HeaderValue{},
+					},
+					Services: []v1.Service{{
+						Name:     "goo",
+						Port:     123,
+						Protocol: &tlsProto,
+						UpstreamValidation: &v1.UpstreamValidation{
+							CACertificate: fmt.Sprintf("%s/knative-serving-certs", system.Namespace()),
+							SubjectName:   "data-plane.knative.dev",
+						},
+						Weight: 100,
+						RequestHeadersPolicy: &v1.HeadersPolicy{
+							Set: []v1.HeaderValue{{
+								Name:  "Baz",
+								Value: "blah",
+							}, {
+								Name:  "Bleep",
+								Value: "bloop",
+							}},
+						},
+					}},
+				}, {
+					EnableWebsockets: true,
+					PermitInsecure:   true,
+					TimeoutPolicy: &v1.TimeoutPolicy{
+						Response: "infinity",
+						Idle:     "infinity",
+					},
+					Conditions: []v1.MatchCondition{{
+						Prefix: "/.well-known/acme-challenge/some-challenge",
+					}},
+					RetryPolicy: defaultRetryPolicy(),
+					RequestHeadersPolicy: &v1.HeadersPolicy{
+						Set: []v1.HeaderValue{},
+					},
+					Services: []v1.Service{{
+						Name:   "acme-http-solver",
+						Port:   8089,
+						Weight: 100,
+					}},
+				}},
+			},
+		}},
+	},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
# Changes

:bug: Fixes #862
- Unencrypt request back to envoy for domainmappings when internal encryption is enabled
- net-contour currently sets the protocol as h2 for services with ports named http2 when internal encryption. This change will set the protocol as h2c if the kingress has domainmapping labels.
- This isn't the perfect fix, but it does at least make domainmappings work properly when using internal encryption. I hope this is enough for the beta stage of these features.

:bug: internal encryption breaks http01 challenges
- Don't encrypt traffic to http challenge endpoint, use http instead
- The current implementation tries to use tls to connect to the http01 challenge endpoint when internal encryption is enabled, auto-tls is enabled, and httpOption is redirected, 
- This path is currently hidden by flawed cert-manager behavior that is being addressed [here](https://github.com/knative-sandbox/net-certmanager/pull/481). So long as this fix is included before or in the same release as the cert-manager changes, I don't think anyone will run into this.

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
 

<!-- Please include the 'why' behind your changes if no issue exists -->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->
```release-note
Fixes issue where DomainMappings do not become ready when Internal Encryption is enabled.
```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [knative/docs]: <issue or pr link>
- [Feature Track]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
N/A
```
