### PR TITLE
[release-1.9] trigger to build release with go1.19.6

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,7 @@
 module knative.dev/net-contour
 
+// Trigger build
+// see: https://github.com/knative/serving/issues/13747
 go 1.18
 
 require (


### PR DESCRIPTION
See: https://github.com/knative/serving/issues/13747