### PR TITLE
refactor: use new dataplane-trust flag and new certificate name ServingRoutingCertName

### DIFF
--- a/pkg/reconciler/contour/contour.go
+++ b/pkg/reconciler/contour/contour.go
@@ -40,6 +40,7 @@ import (
 	"knative.dev/net-contour/pkg/reconciler/contour/resources/names"
 	"knative.dev/networking/pkg/apis/networking"
 	"knative.dev/networking/pkg/apis/networking/v1alpha1"
+	netcfg "knative.dev/networking/pkg/config"
 	"knative.dev/networking/pkg/status"
 	"knative.dev/pkg/kmp"
 	"knative.dev/pkg/logging"
@@ -189,14 +190,14 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, ing *v1alpha1.Ingress) r
 		for _, port := range svc.Spec.Ports {
 
 			if port.Name == networking.ServicePortNameH2C {
-				if cfg.Network != nil && cfg.Network.InternalEncryption {
+				if cfg.Network != nil && (cfg.Network.DataplaneTrust != netcfg.TrustDisabled) {
 					serviceToProtocol[name] = resources.InternalEncryptionH2Protocol
 					logger.Debugf("marked an http2 svc %s as h2 for internal encryption", name)
 				} else {
 					serviceToProtocol[name] = "h2c"
 				}
 				break
-			} else if cfg.Network != nil && cfg.Network.InternalEncryption {
+			} else if cfg.Network != nil && (cfg.Network.DataplaneTrust != netcfg.TrustDisabled) {
 				serviceToProtocol[name] = resources.InternalEncryptionProtocol
 				logger.Debugf("marked a svc %s as tls for internal encryption", name)
 				break

--- a/pkg/reconciler/contour/contour_test.go
+++ b/pkg/reconciler/contour/contour_test.go
@@ -721,7 +721,9 @@ var (
 			},
 		},
 		Network: &netconfig.Config{
-			InternalEncryption: true,
+			// Right now, any trust configuration which is not Disabled should be equivalent to what we used to have as "internal-encryption=enabled"
+			// TODO: Expand test coverage when more trust states are implemented
+			DataplaneTrust: netconfig.TrustMinimal,
 		},
 	}
 )

--- a/pkg/reconciler/contour/resources/httpproxy.go
+++ b/pkg/reconciler/contour/resources/httpproxy.go
@@ -207,10 +207,10 @@ func MakeHTTPProxies(ctx context.Context, ing *v1alpha1.Ingress, serviceToProtoc
 					}
 				}
 
-				if cfg.Network != nil && cfg.Network.InternalEncryption {
+				if cfg.Network != nil && (cfg.Network.DataplaneTrust != netcfg.TrustDisabled) {
 					svc.UpstreamValidation = &v1.UpstreamValidation{
-						CACertificate: fmt.Sprintf("%s/%s", system.Namespace(), netcfg.ServingInternalCertName),
-						SubjectName:   certificates.FakeDnsName,
+						CACertificate: fmt.Sprintf("%s/%s", system.Namespace(), netcfg.ServingRoutingCertName),
+						SubjectName:   certificates.LegacyFakeDnsName,
 					}
 				}
 

--- a/pkg/reconciler/contour/resources/httpproxy_test.go
+++ b/pkg/reconciler/contour/resources/httpproxy_test.go
@@ -1967,7 +1967,7 @@ func TestMakeProxiesInternalEncryption(t *testing.T) {
 						Port:     123,
 						Protocol: &tlsProto,
 						UpstreamValidation: &v1.UpstreamValidation{
-							CACertificate: fmt.Sprintf("%s/knative-serving-certs", system.Namespace()),
+							CACertificate: fmt.Sprintf("%s/%s", system.Namespace(), netcfg.ServingRoutingCertName),
 							SubjectName:   "data-plane.knative.dev",
 						},
 						Weight: 100,
@@ -2000,7 +2000,7 @@ func TestMakeProxiesInternalEncryption(t *testing.T) {
 						Port:     123,
 						Protocol: &tlsProto,
 						UpstreamValidation: &v1.UpstreamValidation{
-							CACertificate: fmt.Sprintf("%s/knative-serving-certs", system.Namespace()),
+							CACertificate: fmt.Sprintf("%s/%s", system.Namespace(), netcfg.ServingRoutingCertName),
 							SubjectName:   "data-plane.knative.dev",
 						},
 						Weight: 100,
@@ -2104,7 +2104,7 @@ func TestMakeProxiesInternalEncryption(t *testing.T) {
 						Port:     123,
 						Protocol: &h2Proto,
 						UpstreamValidation: &v1.UpstreamValidation{
-							CACertificate: fmt.Sprintf("%s/knative-serving-certs", system.Namespace()),
+							CACertificate: fmt.Sprintf("%s/%s", system.Namespace(), netcfg.ServingRoutingCertName),
 							SubjectName:   "data-plane.knative.dev",
 						},
 						Weight: 100,
@@ -2137,7 +2137,7 @@ func TestMakeProxiesInternalEncryption(t *testing.T) {
 						Port:     123,
 						Protocol: &h2Proto,
 						UpstreamValidation: &v1.UpstreamValidation{
-							CACertificate: fmt.Sprintf("%s/knative-serving-certs", system.Namespace()),
+							CACertificate: fmt.Sprintf("%s/%s", system.Namespace(), netcfg.ServingRoutingCertName),
 							SubjectName:   "data-plane.knative.dev",
 						},
 						Weight: 100,
@@ -2257,7 +2257,7 @@ func TestMakeProxiesInternalEncryption(t *testing.T) {
 						Port:     123,
 						Protocol: &tlsProto,
 						UpstreamValidation: &v1.UpstreamValidation{
-							CACertificate: fmt.Sprintf("%s/knative-serving-certs", system.Namespace()),
+							CACertificate: fmt.Sprintf("%s/%s", system.Namespace(), netcfg.ServingRoutingCertName),
 							SubjectName:   "data-plane.knative.dev",
 						},
 						Weight: 100,
@@ -2314,7 +2314,7 @@ func TestMakeProxiesInternalEncryption(t *testing.T) {
 						Port:     123,
 						Protocol: &tlsProto,
 						UpstreamValidation: &v1.UpstreamValidation{
-							CACertificate: fmt.Sprintf("%s/knative-serving-certs", system.Namespace()),
+							CACertificate: fmt.Sprintf("%s/%s", system.Namespace(), netcfg.ServingRoutingCertName),
 							SubjectName:   "data-plane.knative.dev",
 						},
 						Weight: 100,
@@ -2365,7 +2365,9 @@ func TestMakeProxiesInternalEncryption(t *testing.T) {
 					TimeoutPolicyIdle:     "infinity",
 				},
 				Network: &netcfg.Config{
-					InternalEncryption: true,
+					// Right now, any trust configuration which is not Disabled should be equivalent to what we used to have as "internal-encryption=enabled"
+					// TODO: Expand test coverage when more trust states are implemented
+					DataplaneTrust: netcfg.TrustMinimal,
 				},
 			}
 


### PR DESCRIPTION

<!-- Thanks for sending a pull request! -->

# Changes

<!-- 
Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! 

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- :broom: following on from https://github.com/knative/networking/pull/778
- internal-encryption flag is deprecated, remove usage. Replace with dataplane-trust flag.
- dataplane-trust = minimal is equivalent to what is implemented for internal-encryption = enabled
- Also use the new secret name that the certs will be stored in, [ServingRoutingCertName](https://github.com/knative/networking/blob/0dbe4f9cade877c06f7af2acccaa9e978c7dd5e4/pkg/config/config.go#L78)

<!--
In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: api-change, bug, cleanup, deprecation, removal, documentation, enhancement, performance

-->
/kind cleanup 
/kind deprecation

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->
```release-note
net-contour respects the dataplane-trust config to enable internal encryption. No longer supports deprecated "internal-encryption" flag
```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [knative/docs]: <issue or pr link>
- [Feature Track]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
N/A
```
